### PR TITLE
Migrate template schema from pdfmeVersion to schemaVersion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A powerful and flexible PDF generation library written in Rust, inspired by [pdf
 - **Advanced table rendering** - Tables can span multiple pages automatically with proper pagination
 - **Text styling with borders** - Text elements support borders, backgrounds, and comprehensive styling options
 - **Flexible styling** - Comprehensive styling options for colors, borders, alignment, and spacing
+- **Schema versioning** - Templates now use `schemaVersion` field for better version management
 - **High-quality output** - Built on the robust printpdf library
 
 ## Supported Schema Types
@@ -33,7 +34,7 @@ Add PDForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pdforge = "0.7.0"
+pdforge = "0.8.0"
 ```
 
 ## Quick Start
@@ -164,7 +165,7 @@ PDForge uses JSON templates to define PDF layouts. Here's the basic structure:
       }
     ]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }
 ```
 
@@ -458,7 +459,7 @@ Static schemas support special template variables that are automatically populat
       }
     ]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }
 ```
 
@@ -653,6 +654,12 @@ Contributions are welcome! Please feel free to submit issues, feature requests, 
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Version 0.8.0 Changes
+
+- **Breaking Change**: Template schema version field renamed from `pdfmeVersion` to `schemaVersion`
+- All templates now use `schemaVersion: "1.0.0"` for consistency and proper version management
+- Updated to version 0.8.0 to reflect this schema format change
 
 ## Acknowledgments
 

--- a/src/schemas/mod.rs
+++ b/src/schemas/mod.rs
@@ -129,7 +129,7 @@ struct JsonBasePdf {
 struct JsonTemplate {
     schemas: Vec<serde_json::Value>,
     base_pdf: JsonBasePdf,
-    #[serde(rename = "pdfmeVersion")]
+    #[serde(rename = "schemaVersion")]
     version: String,
 }
 

--- a/templates/combined_example.json
+++ b/templates/combined_example.json
@@ -86,5 +86,5 @@
         "height": 297,
         "padding": [20, 10, 20, 10]
     },
-    "pdfmeVersion": "5.3.8"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/image-test.json
+++ b/templates/image-test.json
@@ -47,5 +47,5 @@
             0
         ]
     },
-    "pdfmeVersion": "5.3.5"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/large-tables-spanning.json
+++ b/templates/large-tables-spanning.json
@@ -618,5 +618,5 @@
       10
     ]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/legacy-image-test.json
+++ b/templates/legacy-image-test.json
@@ -20,5 +20,5 @@
         "height": 148,
         "padding": [0, 0, 0, 0]
     },
-    "pdfmeVersion": "5.3.5"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/line-dynamic.json
+++ b/templates/line-dynamic.json
@@ -118,5 +118,5 @@
         "height": 297,
         "padding": [10, 10, 10, 10]
     },
-    "pdfmeVersion": "5.3.8"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/line-example.json
+++ b/templates/line-example.json
@@ -250,5 +250,5 @@
         "height": 297,
         "padding": [10, 10, 10, 10]
     },
-    "pdfmeVersion": "5.3.8"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/multi-table-fixed.json
+++ b/templates/multi-table-fixed.json
@@ -836,5 +836,5 @@
       10
     ]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/multipage.json
+++ b/templates/multipage.json
@@ -589,5 +589,5 @@
       10
     ]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/object-fit-test.json
+++ b/templates/object-fit-test.json
@@ -73,5 +73,5 @@
         "height": 148,
         "padding": [0, 0, 0, 0]
     },
-    "pdfmeVersion": "5.3.5"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/print-renews.json
+++ b/templates/print-renews.json
@@ -420,5 +420,5 @@
             }
         ]
     },
-    "pdfmeVersion": "5.3.5"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/quote.json
+++ b/templates/quote.json
@@ -425,5 +425,5 @@
             }
         ]
     },
-    "pdfmeVersion": "5.3.5"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/static-schema-test.json
+++ b/templates/static-schema-test.json
@@ -64,5 +64,5 @@
       }
     ]
   },
-  "pdfmeVersion": "4.0.0"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/svg.json
+++ b/templates/svg.json
@@ -20,5 +20,5 @@
     "height": 297,
     "padding": [20, 10, 20, 10]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/table.json
+++ b/templates/table.json
@@ -627,5 +627,5 @@
             10
         ]
     },
-    "pdfmeVersion": "5.3.8"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/test_metadata.json
+++ b/templates/test_metadata.json
@@ -16,5 +16,5 @@
         "height": 297,
         "padding": [0, 0, 0, 0]
     },
-    "pdfmeVersion": "4.0.0"
+    "schemaVersion": "1.0.0"
 }

--- a/templates/text-border-test.json
+++ b/templates/text-border-test.json
@@ -112,5 +112,5 @@
       }
     ]
   },
-  "pdfmeVersion": "4.0.0"
+  "schemaVersion": "1.0.0"
 }

--- a/templates/tiger-svg.json
+++ b/templates/tiger-svg.json
@@ -20,5 +20,5 @@
     "height": 297,
     "padding": [20, 10, 20, 10]
   },
-  "pdfmeVersion": "5.3.8"
+  "schemaVersion": "1.0.0"
 }


### PR DESCRIPTION
## Summary

- Replaces `pdfmeVersion` with `schemaVersion` in all JSON templates for better version management
- Standardizes all template versions to `"1.0.0"` format
- Updates codebase to handle new schema version field
- Bumps project version to 0.8.0 to reflect breaking change

## Breaking Changes

This is a **breaking change** that affects all existing templates. Templates using `pdfmeVersion` will need to be updated to use `schemaVersion` instead.

## Changes Made

- ✅ Updated 17 JSON templates in `templates/` directory
- ✅ Modified `JsonTemplate` struct in `src/schemas/mod.rs` 
- ✅ Bumped version from 0.7.2 to 0.8.0 in `Cargo.toml`
- ✅ Updated README.md with schema versioning documentation
- ✅ Added version 0.8.0 changelog section

## Test Plan

- [ ] Build project successfully with `cargo build`
- [ ] Run existing tests with `cargo test`
- [ ] Test template processing with updated schema format
- [ ] Verify examples work with new schema version field

🤖 Generated with [Claude Code](https://claude.ai/code)