### PR TITLE
feat: upgrade printpdf to 0.9.1 with SVG support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Upgraded `printpdf` dependency from pinned git rev (`a88db12`) to published version `0.9.1`
+- Added `svg` feature for `printpdf`, maintaining full SVG support via `svg2pdf 0.13.0`
+- Upgraded `lopdf` from `0.37.0` to `0.39.0` to align with `printpdf 0.9.1`
+
+### Internal
+- `Op::SetFontSize` replaced with `Op::SetFont { font: PdfFontHandle::External(...), size }` (`src/schemas/pdf_utils.rs`)
+- `Op::WriteText` replaced with `Op::ShowText` — font reference removed from text op per new printpdf API
+
 ## [0.10.1] - 2026-02-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "4ba21c7f883cc76d76a41910815b1b212e1ca7870af2bd551565282140660ca5"
 dependencies = [
  "bitflags 2.10.0",
  "bitreader",
- "brotli-decompressor 5.0.0",
+ "brotli-decompressor",
  "byteorder",
  "crc32fast",
  "encoding_rs",
@@ -91,37 +91,9 @@ dependencies = [
  "rustc-hash 1.1.0",
  "tinyvec",
  "ucd-trie",
- "unicode-canonical-combining-class 1.0.0",
- "unicode-general-category 1.1.0",
- "unicode-joining-type 1.0.0",
-]
-
-[[package]]
-name = "allsorts-subset-browser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318f830be541711fe34053ec9c0db9d1bc8eb751ce20baa73e03c2d436015d8b"
-dependencies = [
- "bitflags 1.3.2",
- "bitreader",
- "brotli-decompressor 4.0.3",
- "byteorder",
- "crc32fast",
- "encoding_rs",
- "flate2",
- "glyph-names",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "num-traits",
- "ouroboros",
- "pathfinder_geometry",
- "rustc-hash 1.1.0",
- "tinyvec",
- "ucd-trie",
- "unicode-canonical-combining-class 0.5.0",
- "unicode-general-category 0.6.0",
- "unicode-joining-type 0.7.0",
+ "unicode-canonical-combining-class",
+ "unicode-general-category",
+ "unicode-joining-type",
 ]
 
 [[package]]
@@ -138,6 +110,15 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "approx"
@@ -221,7 +202,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom 8.0.0",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -237,8 +218,9 @@ dependencies = [
 
 [[package]]
 name = "azul-core"
-version = "0.0.5"
-source = "git+https://github.com/fschutt/azul?rev=3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8#3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa50effb9e896df2bc986f640b8ec84de39a90e0e076fd22e096ce5164a7aab"
 dependencies = [
  "azul-css",
  "gl-context-loader",
@@ -249,38 +231,54 @@ dependencies = [
 
 [[package]]
 name = "azul-css"
-version = "0.0.5"
-source = "git+https://github.com/fschutt/azul?rev=3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8#3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff689feae7498a351a30699cc5a4a14dc650dddaca5436d7c5b108a956b707"
 dependencies = [
  "azul-simplecss",
+ "highway",
  "libm",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
 name = "azul-layout"
-version = "0.0.5"
-source = "git+https://github.com/fschutt/azul?rev=3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8#3fe83b9d4c8004ebe96ea0a77660c777fcd05bc8"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e40b81fed0578d2997b9e36b2830972ca852f851d5e98faf699e9273aa6b1b1"
 dependencies = [
- "allsorts-subset-browser",
+ "allsorts",
  "azul-core",
  "azul-css",
+ "base64",
+ "geo",
+ "geo-booleanop",
+ "gl-context-loader",
  "hyphenation",
- "image",
- "roxmltree",
+ "lru",
+ "lyon",
+ "resvg",
+ "roxmltree 0.21.1",
  "rust-fontconfig",
+ "serde",
+ "taffy",
+ "thiserror",
+ "tiny-skia",
  "tinyvec",
  "unicode-bidi",
  "unicode-normalization",
  "unicode-segmentation",
+ "usvg",
  "xmlparser",
  "xmlwriter",
 ]
 
 [[package]]
 name = "azul-simplecss"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78201f8943993f37a3d6d2bbe5fa9a5ab01fac09140848fee98f1551df91bb8a"
+checksum = "8259ebd5ee48a37fd8931116405456fd67efbb5435b4789e45bdbccf5d7dea7e"
 
 [[package]]
 name = "base64"
@@ -349,16 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -852,6 +840,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,7 +869,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -919,6 +922,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+dependencies = [
+ "float_next_after 1.0.0",
+ "geo-types 0.7.18",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust 1.2.0",
+ "rstar",
+]
+
+[[package]]
+name = "geo-booleanop"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b68ff17c819296610e9eee41bdf5eb37f71b09870a95f0086e07d8fcc1f45b"
+dependencies = [
+ "float_next_after 0.1.5",
+ "geo-types 0.6.2",
+ "num-traits",
+ "robust 0.1.2",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7583925a1fdb2b450c461fe0878ba6e99a8f1332b2bc72fb1383fd25b2f13bf2"
+dependencies = [
+ "approx 0.3.2",
+ "num-traits",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+dependencies = [
+ "approx 0.5.1",
+ "num-traits",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,9 +1009,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1009,6 +1073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
+name = "grid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,10 +1090,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1039,9 +1128,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "highway"
-version = "0.8.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1489f81ead4b71a09ddeab6850c0356c0932587637d753f21ee1010ab875b013"
+checksum = "9040319a6910b901d5d49cbada4a99db52836a1b63228a05f7e2b7f8feef89b1"
 
 [[package]]
 name = "html5ever"
@@ -1088,6 +1177,48 @@ dependencies = [
  "fst",
  "serde",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+
+[[package]]
+name = "i_overlay"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
@@ -1474,31 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7c1d3350d071cb86987a6bcb205c7019a0eb70dcad92b454fec722cca8d68b"
-dependencies = [
- "aes",
- "cbc",
- "encoding_rs",
- "flate2",
- "indexmap",
- "itoa 1.0.15",
- "log",
- "md-5",
- "nom 7.1.3",
- "nom_locate 4.2.0",
- "rangemap",
- "thiserror",
- "time",
- "weezl",
-]
-
-[[package]]
-name = "lopdf"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674a3504c1224247e00762afb90690991b673c461f6779565e055e91926a49da"
+checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
 dependencies = [
  "aes",
  "bitflags 2.10.0",
@@ -1513,8 +1622,8 @@ dependencies = [
  "jiff",
  "log",
  "md-5",
- "nom 8.0.0",
- "nom_locate 5.0.0",
+ "nom",
+ "nom_locate",
  "rand 0.9.2",
  "rangemap",
  "rayon",
@@ -1522,7 +1631,66 @@ dependencies = [
  "stringprep",
  "thiserror",
  "time",
+ "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9815fac08e6fd96733a11dce4f9d15a3f338e96a2e2311ee21e1b738efc2bc0f"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05a35a7dd71b845ff317ce1834c4185506b79790294bde397df8d5c23031e357"
+dependencies = [
+ "float_next_after 1.0.0",
+ "lyon_path",
+ "num-traits",
 ]
 
 [[package]]
@@ -1587,12 +1755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,32 +1798,11 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom_locate"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 7.1.3",
 ]
 
 [[package]]
@@ -1672,7 +1813,7 @@ checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
- "nom 8.0.0",
+ "nom",
 ]
 
 [[package]]
@@ -1735,6 +1876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1782,7 +1924,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "fast-srgb8",
  "palette_derive",
  "phf 0.11.3",
@@ -1877,14 +2019,14 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "csscolorparser",
  "derive-new",
  "icu_segmenter",
  "image",
- "lopdf 0.37.0",
+ "lopdf",
  "palette",
  "printpdf",
  "qrcode",
@@ -2127,18 +2269,20 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "printpdf"
-version = "0.8.2"
-source = "git+https://github.com/fschutt/printpdf?rev=a88db12bdc020e0f3743cc4bb22b08826d733b9c#a88db12bdc020e0f3743cc4bb22b08826d733b9c"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91dac59ed5eed56d899517c12cb9f00756738731926b54e513732a36f49a83d"
 dependencies = [
- "allsorts-subset-browser",
+ "allsorts",
  "azul-core",
  "azul-css",
  "azul-layout",
  "base64",
  "flate2",
+ "getrandom 0.3.4",
  "image",
  "kuchiki",
- "lopdf 0.35.0",
+ "lopdf",
  "rust-fontconfig",
  "serde",
  "serde_derive",
@@ -2518,16 +2662,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222155e5550abd9100afdcdefbd08aa1b856d226b60e327044ec21b1ece2f78e"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
-name = "rust-fontconfig"
-version = "1.2.1"
+name = "roxmltree"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7761749fc733edcfb556442c62e6f0a033a4129d4351830a05b6de4aacf836"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-fontconfig"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f18e13793c89413ba7e7c991db5f56527803d4706df6a14291d045cd67db2"
 dependencies = [
  "allsorts",
  "base64",
@@ -2847,6 +3023,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "subsetter"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3117,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "taffy"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
 ]
 
 [[package]]
@@ -3112,12 +3322,6 @@ checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
 
 [[package]]
 name = "unicode-canonical-combining-class"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6925586af9268182c711e47c0853ed84131049efaca41776d0ca97f983865c32"
-
-[[package]]
-name = "unicode-canonical-combining-class"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41c99d5174052d02ce765418e826597a1be18f32c114e35d9e22f92390239561"
@@ -3130,12 +3334,6 @@ checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
 name = "unicode-general-category"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
-
-[[package]]
-name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
@@ -3145,12 +3343,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-joining-type"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f8cb47ccb8bc750808755af3071da4a10dcd147b68fc874b7ae4b12543f6f5"
 
 [[package]]
 name = "unicode-joining-type"
@@ -3205,7 +3397,7 @@ dependencies = [
  "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz",
  "simplecss",
  "siphasher 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,14 @@ csscolorparser = "0.7.0"
 derive-new = "0.7.0"
 icu_segmenter = { version = "1.5.0", features = ["serde"] }
 image = { version = "0.25.5", features = ["png"] }
-lopdf = "0.37.0"
+lopdf = "0.39.0"
 palette = "0.7.6"
-#printpdf = { version = "0.8", features = ["bmp", "png", "jpeg"]}
-#printpdf = { git = "https://github.com/kyasu1/printpdf", rev="86649854ea27ef47fc2ca432da28e7163a87d8e7", features = ["bmp", "png", "jpeg"]}
-printpdf = { git = "https://github.com/fschutt/printpdf", features = [
+printpdf = { version = "0.9.1", features = [
     "bmp",
     "png",
     "jpeg",
-], rev = "a88db12bdc020e0f3743cc4bb22b08826d733b9c" }
+    "svg",
+] }
 qrcode = "0.14.1"
 serde = { version = "1.0.217", features = ["derive", "serde_derive"] }
 serde_json = "1.0.139"

--- a/docs/printpdf-0.9.1-migration-plan.md
+++ b/docs/printpdf-0.9.1-migration-plan.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-本ドキュメントは、pdforgeが依存する printpdf クレートを現在のピン留めコミット (`a88db12`) から バージョン `0.9.1` (masterブランチ最新: `8a554fc`) へ移行するための計画です。
+本ドキュメントは、pdforgeが依存する printpdf クレートを現在のピン留めコミット (`a88db12`) から バージョン `0.9.1` (masterブランチ最新: `8a554fc`) へ移行するための計画です。SVGサポートを含む完全移行を対象とします。
 
 ## 現状
 
@@ -23,14 +23,20 @@ printpdf = { version = "0.9.1", features = [
     "bmp",
     "png",
     "jpeg",
+    "svg",
 ] }
 ```
 
+`svg` feature は `html` feature → `azul-layout` (text_layout_hyphenation) + `svg2pdf = "0.13.0"` を引き込む。
+依存クレートはすべて crates.io に公開済みのため、git 依存なしで解決可能。
+
+---
+
 ## 破壊的変更と対応が必要な箇所
 
-### 1. `Op::SetFontSize` → `Op::SetFont` への変更 (最重要)
+### 1. `Op::SetFontSize` → `Op::SetFont` への変更
 
-**変更前 (現在のコード):**
+**変更前:**
 ```rust
 Op::SetFontSize {
     size: font_size,
@@ -40,7 +46,7 @@ Op::SetFontSize {
 
 **変更後:**
 
-旧APIの `SetFontSize` と `SetFont` が統合され、新しい `Op::SetFont` は `PdfFontHandle` enum を受け取るようになった。
+旧 `SetFontSize` と `SetFont` が統合され、新 `Op::SetFont` は `PdfFontHandle` enum を受け取る。
 
 ```rust
 Op::SetFont {
@@ -49,11 +55,11 @@ Op::SetFont {
 },
 ```
 
-**対象ファイル:** `src/schemas/pdf_utils.rs:167`
+**対象ファイル:** `src/schemas/pdf_utils.rs`
 
 ---
 
-### 2. `Op::WriteText` → `Op::ShowText` への変更 (最重要)
+### 2. `Op::WriteText` → `Op::ShowText` への変更
 
 **変更前:**
 ```rust
@@ -65,7 +71,7 @@ Op::WriteText {
 
 **変更後:**
 
-新APIでは `ShowText` はフォント参照を持たない。フォントは直前の `SetFont` オペレーションで設定する。
+新 `ShowText` はフォント参照を持たない。フォントは直前の `SetFont` で設定済みのため不要。
 
 ```rust
 Op::ShowText {
@@ -73,27 +79,27 @@ Op::ShowText {
 },
 ```
 
-**対象ファイル:** `src/schemas/pdf_utils.rs:175`
+**対象ファイル:** `src/schemas/pdf_utils.rs`
 
 ---
 
-### 3. `PdfFontHandle` の import 追加
+### 3. `lopdf` バージョンの更新
 
-`Op::SetFont` で使用する `PdfFontHandle` を import する必要がある。
+0.9.1 は `lopdf = "0.39.0"` を使用。pdforge が直接依存している `lopdf = "0.37.0"` をあわせて更新する。
 
-**対象ファイル:** `src/schemas/pdf_utils.rs`
+**対象ファイル:** `Cargo.toml`
 
-```rust
-use printpdf::{Op, PdfFontHandle, TextItem, /* ... */};
-```
+---
 
-`use printpdf::*;` を使っている場合は自動的に解決される。
+## SVG サポートについて
+
+`svg` feature を有効にすることで `printpdf::svg::Svg::parse()` は引き続き同じシグネチャで使用可能。**`src/schemas/svg.rs` のコード変更は不要。**
+
+`svg` feature を有効にすると `azul-layout` 経由で lyon, tiny-skia, usvg, resvg 等の依存が引き込まれ、初回ビルド時間が増加するが、機能的な問題はない。
 
 ---
 
 ## 互換性が確認できた API（変更不要）
-
-以下の API はすべて 0.9.1 でも同じシグネチャで存在する:
 
 | API | ファイル |
 |-----|---------|
@@ -133,92 +139,27 @@ use printpdf::{Op, PdfFontHandle, TextItem, /* ... */};
 
 ## 実装手順
 
-### Step 1: Cargo.toml の更新
+### Step 1: `Cargo.toml` の更新
 
-```toml
-# 変更前
-printpdf = { git = "https://github.com/fschutt/printpdf", features = [
-    "bmp",
-    "png",
-    "jpeg",
-], rev = "a88db12bdc020e0f3743cc4bb22b08826d733b9c" }
-
-# 変更後
-printpdf = { version = "0.9.1", features = [
-    "bmp",
-    "png",
-    "jpeg",
-] }
-```
+- `printpdf` を git rev 指定から `version = "0.9.1"` に変更し、`"svg"` feature を追加
+- `lopdf` を `"0.37.0"` から `"0.39.0"` に更新
 
 ### Step 2: `src/schemas/pdf_utils.rs` の修正
 
-`create_text_ops_with_font` 関数内の2箇所を変更する:
+`create_text_ops_with_font` 関数内の2箇所を変更:
 
-**L167: `Op::SetFontSize` → `Op::SetFont`**
-```rust
-// 変更前
-Op::SetFontSize {
-    size: font_size,
-    font: font_id.clone(),
-},
+- `Op::SetFontSize { size, font }` → `Op::SetFont { font: PdfFontHandle::External(font_id), size }`
+- `Op::WriteText { items, font }` → `Op::ShowText { items }`
 
-// 変更後
-Op::SetFont {
-    font: PdfFontHandle::External(font_id.clone()),
-    size: font_size,
-},
-```
-
-**L175: `Op::WriteText` → `Op::ShowText`**
-```rust
-// 変更前
-Op::WriteText {
-    items: vec![TextItem::Text(sanitized_line)],
-    font: font_id.clone(),
-},
-
-// 変更後
-Op::ShowText {
-    items: vec![TextItem::Text(sanitized_line)],
-},
-```
-
-### Step 3: ビルド確認
+### Step 3: ビルド確認・テスト
 
 ```bash
 cargo build
-```
-
-### Step 4: テスト実行
-
-```bash
 cargo test
 cargo test --test thread_safety
-```
-
-### Step 5: 動作確認
-
-```bash
 cargo run --example simple
 cargo run --example font_from_bytes
 ```
-
----
-
-## 注意事項
-
-### SVG featureについて
-
-0.9.1 では `svg` feature が `html` feature（azul-layout依存）に依存するようになった。pdforgeは現在 SVG に `printpdf::svg::Svg::parse()` を使用しているが、これは `svg` feature が必要。
-
-ただし `svg` feature を有効にすると `azul-layout` など多数の依存が引き込まれる。現時点では `svg` feature を `Cargo.toml` に追加するか、あるいは SVG サポートを削除・代替実装することを検討する必要がある。
-
-**推奨**: まず `svg` feature なしでビルドし、SVG使用箇所のコンパイルエラーを確認してから判断する。
-
-### `lopdf` バージョン
-
-0.9.1 は `lopdf = "0.39.0"` を使用。pdforge も `lopdf = "0.37.0"` を直接依存しているため、バージョン競合が起きる可能性がある。Cargo.toml の `lopdf` バージョンを `0.39.0` に更新するか、削除して printpdf 経由で使うことを検討する。
 
 ---
 
@@ -226,7 +167,6 @@ cargo run --example font_from_bytes
 
 | リスク | 重要度 | 対応 |
 |--------|--------|------|
-| `Op::SetFontSize`/`WriteText` の名称変更 | 高 | Step 2 で対応 |
-| SVG feature の依存関係変化 | 中 | ビルドエラーを確認して判断 |
-| `lopdf` バージョン競合 | 低〜中 | Cargo.lock で Cargo が解決、問題あれば手動調整 |
-| crates.io への公開遅延 | 低 | 未公開の場合は git + tag 指定で対応可能 |
+| `Op::SetFontSize`/`WriteText` の名称変更 | 高 | Step 2 で対応済み |
+| `lopdf` バージョン競合 | 低 | Cargo.toml を 0.39.0 に更新 |
+| svg feature による初回ビルド時間増加 | 低 | 許容範囲 |

--- a/docs/printpdf-0.9.1-migration-plan.md
+++ b/docs/printpdf-0.9.1-migration-plan.md
@@ -1,0 +1,232 @@
+# printpdf 0.9.1 移行プラン
+
+## 概要
+
+本ドキュメントは、pdforgeが依存する printpdf クレートを現在のピン留めコミット (`a88db12`) から バージョン `0.9.1` (masterブランチ最新: `8a554fc`) へ移行するための計画です。
+
+## 現状
+
+`Cargo.toml` の現在の依存定義:
+
+```toml
+printpdf = { git = "https://github.com/fschutt/printpdf", features = [
+    "bmp",
+    "png",
+    "jpeg",
+], rev = "a88db12bdc020e0f3743cc4bb22b08826d733b9c" }
+```
+
+## 変更後の依存定義
+
+```toml
+printpdf = { version = "0.9.1", features = [
+    "bmp",
+    "png",
+    "jpeg",
+] }
+```
+
+## 破壊的変更と対応が必要な箇所
+
+### 1. `Op::SetFontSize` → `Op::SetFont` への変更 (最重要)
+
+**変更前 (現在のコード):**
+```rust
+Op::SetFontSize {
+    size: font_size,
+    font: font_id.clone(),
+},
+```
+
+**変更後:**
+
+旧APIの `SetFontSize` と `SetFont` が統合され、新しい `Op::SetFont` は `PdfFontHandle` enum を受け取るようになった。
+
+```rust
+Op::SetFont {
+    font: PdfFontHandle::External(font_id.clone()),
+    size: font_size,
+},
+```
+
+**対象ファイル:** `src/schemas/pdf_utils.rs:167`
+
+---
+
+### 2. `Op::WriteText` → `Op::ShowText` への変更 (最重要)
+
+**変更前:**
+```rust
+Op::WriteText {
+    items: vec![TextItem::Text(sanitized_line)],
+    font: font_id.clone(),
+},
+```
+
+**変更後:**
+
+新APIでは `ShowText` はフォント参照を持たない。フォントは直前の `SetFont` オペレーションで設定する。
+
+```rust
+Op::ShowText {
+    items: vec![TextItem::Text(sanitized_line)],
+},
+```
+
+**対象ファイル:** `src/schemas/pdf_utils.rs:175`
+
+---
+
+### 3. `PdfFontHandle` の import 追加
+
+`Op::SetFont` で使用する `PdfFontHandle` を import する必要がある。
+
+**対象ファイル:** `src/schemas/pdf_utils.rs`
+
+```rust
+use printpdf::{Op, PdfFontHandle, TextItem, /* ... */};
+```
+
+`use printpdf::*;` を使っている場合は自動的に解決される。
+
+---
+
+## 互換性が確認できた API（変更不要）
+
+以下の API はすべて 0.9.1 でも同じシグネチャで存在する:
+
+| API | ファイル |
+|-----|---------|
+| `PdfDocument::new()` | `src/lib.rs` |
+| `PdfDocument::add_font(&ParsedFont) -> FontId` | `src/lib.rs` |
+| `PdfDocument::add_image(&RawImage) -> XObjectId` | `src/schemas/image.rs` |
+| `PdfDocument::add_xobject(&ExternalXObject) -> XObjectId` | `src/schemas/svg.rs` |
+| `PdfDocument::with_pages(Vec<PdfPage>) -> &mut Self` | `src/schemas/mod.rs` |
+| `PdfDocument::save(&PdfSaveOptions, &mut Vec<PdfWarnMsg>) -> Vec<u8>` | `src/schemas/mod.rs` |
+| `PdfPage::new(Mm, Mm, Vec<Op>)` | `src/schemas/mod.rs` |
+| `PdfSaveOptions { optimize, subset_fonts, secure, image_optimization }` | `src/schemas/mod.rs` |
+| `ParsedFont::from_bytes(&[u8], usize, &mut Vec<_>) -> Option<Self>` | `src/lib.rs` |
+| `ParsedFont::lookup_glyph_index(u32)` | `src/font.rs`, `src/schemas/pdf_utils.rs` |
+| `ParsedFont::get_horizontal_advance(u16)` | `src/font.rs` |
+| `RawImage::decode_from_bytes(&[u8], &mut Vec<_>)` | `src/schemas/image.rs` |
+| `RawImage { width, height }` | `src/schemas/image.rs` |
+| `XObjectTransform { translate_x, translate_y, rotate, scale_x, scale_y, dpi }` | `src/schemas/image.rs`, `src/schemas/base.rs` |
+| `Svg::parse(&str, &mut Vec<_>) -> Result<ExternalXObject, _>` | `src/schemas/svg.rs` |
+| `Op::SaveGraphicsState` / `RestoreGraphicsState` | 複数ファイル |
+| `Op::SetTransformationMatrix` | 複数ファイル |
+| `Op::StartTextSection` / `EndTextSection` | `src/schemas/pdf_utils.rs` |
+| `Op::SetTextMatrix` | `src/schemas/pdf_utils.rs` |
+| `Op::SetLineHeight` | `src/schemas/pdf_utils.rs` |
+| `Op::SetFillColor` / `SetOutlineColor` / `SetOutlineThickness` | 複数ファイル |
+| `Op::SetCharacterSpacing` | `src/schemas/pdf_utils.rs` |
+| `Op::UseXobject { id, transform }` | `src/schemas/svg.rs`, `src/schemas/image.rs` |
+| `Op::DrawPolygon { polygon }` | 複数ファイル |
+| `Mm`, `Pt`, `Px` | 全体 |
+| `Point`, `LinePoint`, `Line`, `Polygon`, `PolygonRing` | 複数ファイル |
+| `PaintMode`, `WindingOrder` | 複数ファイル |
+| `Color`, `Rgb` | 複数ファイル |
+| `CurTransMat`, `TextMatrix` | 複数ファイル |
+| `FontId` | 全体 |
+| `TextItem::Text(String)` | `src/schemas/pdf_utils.rs` |
+
+---
+
+## 実装手順
+
+### Step 1: Cargo.toml の更新
+
+```toml
+# 変更前
+printpdf = { git = "https://github.com/fschutt/printpdf", features = [
+    "bmp",
+    "png",
+    "jpeg",
+], rev = "a88db12bdc020e0f3743cc4bb22b08826d733b9c" }
+
+# 変更後
+printpdf = { version = "0.9.1", features = [
+    "bmp",
+    "png",
+    "jpeg",
+] }
+```
+
+### Step 2: `src/schemas/pdf_utils.rs` の修正
+
+`create_text_ops_with_font` 関数内の2箇所を変更する:
+
+**L167: `Op::SetFontSize` → `Op::SetFont`**
+```rust
+// 変更前
+Op::SetFontSize {
+    size: font_size,
+    font: font_id.clone(),
+},
+
+// 変更後
+Op::SetFont {
+    font: PdfFontHandle::External(font_id.clone()),
+    size: font_size,
+},
+```
+
+**L175: `Op::WriteText` → `Op::ShowText`**
+```rust
+// 変更前
+Op::WriteText {
+    items: vec![TextItem::Text(sanitized_line)],
+    font: font_id.clone(),
+},
+
+// 変更後
+Op::ShowText {
+    items: vec![TextItem::Text(sanitized_line)],
+},
+```
+
+### Step 3: ビルド確認
+
+```bash
+cargo build
+```
+
+### Step 4: テスト実行
+
+```bash
+cargo test
+cargo test --test thread_safety
+```
+
+### Step 5: 動作確認
+
+```bash
+cargo run --example simple
+cargo run --example font_from_bytes
+```
+
+---
+
+## 注意事項
+
+### SVG featureについて
+
+0.9.1 では `svg` feature が `html` feature（azul-layout依存）に依存するようになった。pdforgeは現在 SVG に `printpdf::svg::Svg::parse()` を使用しているが、これは `svg` feature が必要。
+
+ただし `svg` feature を有効にすると `azul-layout` など多数の依存が引き込まれる。現時点では `svg` feature を `Cargo.toml` に追加するか、あるいは SVG サポートを削除・代替実装することを検討する必要がある。
+
+**推奨**: まず `svg` feature なしでビルドし、SVG使用箇所のコンパイルエラーを確認してから判断する。
+
+### `lopdf` バージョン
+
+0.9.1 は `lopdf = "0.39.0"` を使用。pdforge も `lopdf = "0.37.0"` を直接依存しているため、バージョン競合が起きる可能性がある。Cargo.toml の `lopdf` バージョンを `0.39.0` に更新するか、削除して printpdf 経由で使うことを検討する。
+
+---
+
+## リスク評価
+
+| リスク | 重要度 | 対応 |
+|--------|--------|------|
+| `Op::SetFontSize`/`WriteText` の名称変更 | 高 | Step 2 で対応 |
+| SVG feature の依存関係変化 | 中 | ビルドエラーを確認して判断 |
+| `lopdf` バージョン競合 | 低〜中 | Cargo.lock で Cargo が解決、問題あれば手動調整 |
+| crates.io への公開遅延 | 低 | 未公開の場合は git + tag 指定で対応可能 |

--- a/src/schemas/pdf_utils.rs
+++ b/src/schemas/pdf_utils.rs
@@ -164,17 +164,16 @@ pub fn create_text_ops_with_font(
                 icc_profile: None,
             }),
         },
-        Op::SetFontSize {
+        Op::SetFont {
+            font: PdfFontHandle::External(font_id.clone()),
             size: font_size,
-            font: font_id.clone(),
         },
         Op::SetTextMatrix { matrix },
         Op::SetCharacterSpacing {
             multiplier: character_spacing.0,
         },
-        Op::WriteText {
+        Op::ShowText {
             items: vec![TextItem::Text(sanitized_line)],
-            font: font_id.clone(),
         },
         Op::EndTextSection,
         Op::RestoreGraphicsState,


### PR DESCRIPTION
## Summary

- `printpdf` を git rev ピン留め (`a88db12`) から公開バージョン `0.9.1` に移行
- `svg` feature を追加し、`svg2pdf 0.13.0` 経由で SVG サポートを維持
- `lopdf` を `0.37.0` → `0.39.0` に更新（printpdf 0.9.1 との整合）
- printpdf 0.9.1 の破壊的 API 変更に対応（`Op::SetFontSize` → `Op::SetFont`、`Op::WriteText` → `Op::ShowText`）

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `Cargo.toml` | printpdf 0.9.1 + svg feature、lopdf 0.39.0 |
| `src/schemas/pdf_utils.rs` | Op enum の名称変更に対応 |
| `docs/printpdf-0.9.1-migration-plan.md` | 移行プラン（新規追加） |
| `CHANGELOG.md` | Unreleased セクションに記載 |

## Test plan

- [x] `cargo build` — エラーなし
- [x] `cargo test` — ユニットテスト 24/24 パス
- [ ] インテグレーションテスト 2件の失敗は本 PR 以前から存在する既知の問題（フォントファイル未ロード）であり、今回の移行とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)