### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-12
+
 ### Changed
 - Template variables are now rendered only inside JSON string values. This prevents user input from breaking or injecting JSON structure, but templates that relied on Tera expanding outside string values to generate JSON arrays or objects must be rewritten.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add PDForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pdforge = "0.11.0"
+pdforge = "0.11.1"
 ```
 
 ## Quick Start
@@ -886,6 +886,12 @@ Contributions are welcome! Please feel free to submit issues, feature requests, 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
 ## Recent Changes
+
+### Version 0.11.1
+- **Render Correctness**: Repeated `render()` calls no longer accumulate pages from previous renders
+- **Template Safety**: Template variables are rendered inside JSON string values, preserving quotes, backslashes, and newlines safely
+- **Panic Fixes**: Empty `DynamicText` and unsupported nested schemas now return stable results instead of panicking
+- **Layout Fixes**: Nested schemas use their parent width instead of assuming A4 width
 
 ### Version 0.11.0
 - **New Text Wrapping Control**: Added `lineBreakMode` with `word` and `char` options for `text`, `dynamicText`, and table text cells


### PR DESCRIPTION
## Summary

- Bump crate version from `0.11.0` to `0.11.1` in `Cargo.toml` and `Cargo.lock`.
- Move the current changelog entries into `0.11.1` dated 2026-06-12.
- Update README install and recent changes sections for `0.11.1`.

## Verification

- `cargo fmt --check`
- `cargo test -- --nocapture`
- `cargo clippy --all-targets`

## Notes

`cargo clippy --all-targets` exits 0 with the existing warnings already present in the project.
