### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-27
+
+### Added
+- Added a height-only `spacer` schema for explicit vertical gaps between flowing tables and dynamic text.
+
+### Changed
+- Tables, dynamic text, and spacers now share page and vertical-position flow state within each template page.
+
 ## [0.11.1] - 2026-06-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add PDForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pdforge = "0.11.1"
+pdforge = "0.12.0"
 ```
 
 ## Quick Start
@@ -886,6 +886,10 @@ Contributions are welcome! Please feel free to submit issues, feature requests, 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
 ## Recent Changes
+
+### Version 0.12.0
+- **Flow Spacer**: Added a height-only `spacer` schema for explicit vertical gaps between tables and dynamic text
+- **Shared Flow State**: Tables, dynamic text, and spacers now share page and vertical-position state within each template page
 
 ### Version 0.11.1
 - **Render Correctness**: Repeated `render()` calls no longer accumulate pages from previous renders


### PR DESCRIPTION
## Summary

- Bump the crate version from `0.11.1` to `0.12.0`.
- Synchronize `Cargo.lock` and README installation guidance.
- Add the `0.12.0` Spacer release notes to CHANGELOG and README.

## Verification

- `cargo check`
- `cargo test -- --nocapture` (79 passed)
- `cargo fmt --check`
- `git diff --check`
