### PR TITLE
chore: bump pdforge to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bump pdforge from 0.12.0 to 0.12.1 after the printpdf 0.11.1 dependency update.
- Update the root package version recorded in `Cargo.lock`.

## Verification

- `cargo test --quiet` (79 passed)
- `cargo fmt --check`
- `git diff --check`

## Context

- Follow-up to #28, which was merged before this version bump was pushed.
