### PR TITLE
chore: update printpdf to 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "derive-new"
@@ -894,11 +891,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1257,47 +1252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,24 +1357,20 @@ dependencies = [
  "aes",
  "bitflags 2.13.1",
  "cbc",
- "chrono",
  "ecb",
  "encoding_rs",
  "flate2",
  "getrandom 0.4.3",
  "indexmap",
  "itoa",
- "jiff",
  "log",
  "md-5",
  "nom",
  "rand 0.10.2",
  "rangemap",
- "rayon",
  "sha2 0.11.0",
  "stringprep",
  "thiserror",
- "time",
  "weezl 0.2.1",
 ]
 
@@ -1742,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "base64",
  "csscolorparser",
@@ -1901,21 +1851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c135f38778ad324d9e9ee68690bac2c1a51f340fdf96ca13e2ab3914eb2e51d8"
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "printpdf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d60130b4b17973f5f5887e4a9e5a73810baf1184d0ad2725632f3536c4682df"
+checksum = "1cfd402796e8894be91392563b267e2a06e9233d0cb8e0879b4fd5d040bfa586"
 dependencies = [
  "allsorts-azul",
  "azul-core",
@@ -1942,7 +1877,6 @@ dependencies = [
  "azul-layout",
  "base64",
  "flate2",
- "getrandom 0.3.4",
  "getrandom 0.4.3",
  "image",
  "lopdf",
@@ -1955,7 +1889,7 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "weezl 0.1.12",
+ "weezl 0.2.1",
  "xmlparser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 
 [dependencies]
@@ -9,9 +9,9 @@ csscolorparser = "0.7.0"
 derive-new = "0.7.0"
 icu_segmenter = { version = "1.5.0", features = ["serde"] }
 image = { version = "0.25.5", features = ["png"] }
-lopdf = "0.44.0"
+lopdf = { version = "0.44.0", default-features = false }
 palette = "0.7.6"
-printpdf = { version = "0.11.1", features = [
+printpdf = { version = "0.11.2", features = [
     "bmp",
     "png",
     "jpeg",


### PR DESCRIPTION
## Summary

- Bump pdforge from 0.12.1 to 0.12.2.
- Update `printpdf` from 0.11.1 to 0.11.2 while preserving the existing BMP, PNG, JPEG, and SVG features.
- Disable unused default features on the direct `lopdf` dependency, matching printpdf 0.11.2 and avoiding re-enabling its problematic `time` integration.
- Refresh `Cargo.lock`, removing unused `jiff` and related transitive dependencies.

## Context

printpdf 0.11.2 fixes dependency resolutions where 0.11.0/0.11.1 could fail to compile with older lockfiles. It also adds declared dependency floors and MSRV metadata, improves SVG font injection, and hardens PDF metadata and ToUnicode parsing.

## Verification

- `cargo test -- --nocapture` (79 passed)
- `cargo fmt --check`
- `git diff --check`
- Generated `line-example.pdf` with external fonts and verified text extraction with `pdftotext`
- Generated `tiger-svg.pdf` to verify SVG rendering
