### PR TITLE
feat(pdf): enable font subsetting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 
 [dependencies]

--- a/src/schemas/mod.rs
+++ b/src/schemas/mod.rs
@@ -975,7 +975,7 @@ impl Template {
         let bytes = doc.with_pages(pages).save(
             &PdfSaveOptions {
                 optimize: false,
-                subset_fonts: false,
+                subset_fonts: true,
                 secure: false,
                 image_optimization: None,
             },


### PR DESCRIPTION
## Summary

- Enable printpdf font subsetting when serializing rendered PDFs.
- Bump pdforge from 0.12.2 to 0.12.3 for the PDF output behavior change.
- Refresh the root package version in `Cargo.lock`.

## Impact

- `inventory_tag.pdf`: 5.79 MB -> 69 KB
- `quote.pdf`: 5.87 MB -> 177 KB
- Multi-page tables, Japanese text, QR codes, and external fonts render equivalently to non-subset output.

## Verification

- `cargo test --quiet` (79 passed)
- `cargo fmt --check`
- `git diff --check`
- Rendered subset and full-font `inventory_tag.pdf` files through Poppler and confirmed pixel-identical output
- Rendered all three pages of subset and full-font `quote.pdf`; visual content and extracted text match apart from generated timestamps

## Notes

The existing ToUnicode extraction behavior can omit some Japanese characters in both full-font and subset output. This is pre-existing and is not changed by this PR.
