### PR TITLE
chore: update printpdf to 0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "agg-rust-azul"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361630274b7329ec95000b76dbaeed33a1187e6b5c215780148865fa19fe69c6"
+checksum = "e782814ac90251de42fae8457a0ca3de88e9ad42cd3a218a57a0f1a3e31e80a2"
 
 [[package]]
 name = "aho-corasick"
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "azul-core"
-version = "0.0.9"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00984ed4bdcc94d6a7ad9de6b3583591d0b1c4c4775ac5f1321bb70c58e81bb0"
+checksum = "9922e02dbcb4b648c04f7a880d6a73b4d628187905cfc9de8dfe80f8de90ebb7"
 dependencies = [
  "azul-css",
  "gl-context-loader",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "azul-css"
-version = "0.0.9"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b4414b61c9628abe8336e908f82c684064528c8ae73de940f68dc19d2554f"
+checksum = "5403f56264a7b6da84b05f557d55ebe936e19d300c07e71d090aa0c232e946d0"
 dependencies = [
  "azul-simplecss",
  "libm",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "azul-layout"
-version = "0.0.10"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05683a24e5e5c1cfb78b08d7c407180bb622523258df03c1500c54c7edf58825"
+checksum = "f19d95c1b4ab80cd85c7c1e199c6343ed74227d7d30e7e07bd72aa26c9d32b95"
 dependencies = [
  "agg-rust-azul",
  "allsorts-azul",
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "printpdf"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfd402796e8894be91392563b267e2a06e9233d0cb8e0879b4fd5d040bfa586"
+checksum = "9a8b6a0dde82e23e89ded1f9537a76b14219517189062d406611e247353d6878"
 dependencies = [
  "allsorts-azul",
  "azul-core",
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "rust-fontconfig"
-version = "4.4.5"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc208ba5149efc7241c54497f6a38343b510c67f24b876236d0c995bbeba0bbe"
+checksum = "a83df0c47410e28febe95e19096298103a4188aa29d2083219e207d24b357ec3"
 dependencies = [
  "allsorts-azul",
  "mmapio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ icu_segmenter = { version = "1.5.0", features = ["serde"] }
 image = { version = "0.25.5", features = ["png"] }
 lopdf = { version = "0.44.0", default-features = false }
 palette = "0.7.6"
-printpdf = { version = "0.11.2", features = [
+printpdf = { version = "0.12.3", features = [
     "bmp",
     "png",
     "jpeg",

--- a/src/schemas/base.rs
+++ b/src/schemas/base.rs
@@ -34,6 +34,7 @@ impl BaseSchema {
             scale_x: Some(ratio * self.width.0),
             scale_y: Some(ratio * self.height.0),
             dpi: Some(dpi),
+            no_auto_scale: false,
         }
     }
 }

--- a/src/schemas/image.rs
+++ b/src/schemas/image.rs
@@ -179,6 +179,7 @@ impl Image {
                     scale_x: Some(scale_factor),
                     scale_y: Some(scale_factor),
                     dpi: Some(dpi),
+                    no_auto_scale: false,
                 }
             }
             ObjectFit::Cover => {
@@ -201,6 +202,7 @@ impl Image {
                     scale_x: Some(scale_factor),
                     scale_y: Some(scale_factor),
                     dpi: Some(dpi),
+                    no_auto_scale: false,
                 }
             }
             ObjectFit::None => {
@@ -213,6 +215,7 @@ impl Image {
                     scale_x: Some(1.0 / ratio),
                     scale_y: Some(1.0 / ratio),
                     dpi: Some(dpi),
+                    no_auto_scale: false,
                 }
             }
             ObjectFit::ScaleDown => {
@@ -235,6 +238,7 @@ impl Image {
                         scale_x: Some(1.0 / ratio),
                         scale_y: Some(1.0 / ratio),
                         dpi: Some(dpi),
+                        no_auto_scale: false,
                     }
                 } else {
                     // Image is too large - use Contain behavior
@@ -262,6 +266,7 @@ impl Image {
                         scale_x: Some(scale_factor / (dpi / 25.4)),
                         scale_y: Some(scale_factor / (dpi / 25.4)),
                         dpi: Some(dpi),
+                        no_auto_scale: false,
                     }
                 }
             }


### PR DESCRIPTION
## 概要

`printpdf` を `0.11.2` → `0.12.3` に更新します。

## 破壊的変更への対応

0.12.3 での唯一のビルド破壊は `XObjectTransform` に追加された **`no_auto_scale: bool`** フィールドです。全6箇所の初期化子（`base.rs` ×1、`image.rs` ×5）に **`no_auto_scale: false`** を設定しました。

- `false` = `UseXobject` が画像に注入する「単位正方形 → ピクセルサイズ」への自動スケールを従来どおり適用（= 0.11.2 と同一挙動）。
- `true` は既存 PDF から解析した、既に配置情報を持つコンテンツ用。今回は該当しないため `false`。

## 検証

- `cargo build` / `cargo test` 全バイナリ pass（FAILED 0）。画像の object-fit 変換ユニットテスト6件を含む。
- `cargo fmt --check` クリア、printpdf 由来の新規警告なし。
- レンダリング確認: `tiger-svg.json`（SVG）・`table.json` の PDF 生成成功。
  - ※ ラスタ画像テンプレートは入力データ／`assets/images`（gitignore）が必要なため CLI 単体では未確認だが、`XObjectTransform` 算出ロジックはユニットテストで担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)