### PR TITLE
chore(release): 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-23
+
+### Changed
+- Updated `printpdf` to 0.12.3. The new `XObjectTransform.no_auto_scale` field is set to `false` everywhere, preserving image/SVG placement behavior.
+
 ## [0.13.0] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## 概要

パッチリリース **0.13.1**。マージ済みの printpdf 0.12.3 更新（#33）を取り込むためのバージョンアップです。

## 変更

- `Cargo.toml` / `Cargo.lock`: `0.13.0` → `0.13.1`
- `CHANGELOG.md`: `[0.13.1]` エントリを追加（printpdf 0.12.3 更新を記載）

コード変更はありません。`cargo build` 成功。

## マージ後

`v0.13.1` タグを作成してプッシュします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)