### PR TITLE
chore: ignore local Codex config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ printpdf/
 assets/
 .idea/
 .claude/settings.local.json
+.codex/
 examples/pdf/
 cv_ql800_jpn_raster_101.pdf


### PR DESCRIPTION
## Summary

- Add `.codex/` to `.gitignore`.
- Keep user-specific Codex hook configuration out of version control.

## Verification

- `git diff --check`