### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-26
+
+### Added
+- `PDForgeBuilder::add_font_with_index` and `add_font_from_file_with_index` for selecting a specific face by index inside a TrueType/OpenType Collection (`.ttc`/`.otc`). `add_font`/`add_font_from_file` continue to load face 0 by default.
+
 ## [0.13.1] - 2026-07-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bumps `pdforge` to `0.14.0` (minor) for the new `add_font_with_index`/`add_font_from_file_with_index` TTC/OTC face-selection API added in #36.
- Adds a `[0.14.0]` CHANGELOG entry.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (full suite)