### PR TITLE
fix: measure text height at the width it is actually rendered at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `Text::get_height` wrapped text at the full `base.width` while `Text::render` wraps at `base.width` minus horizontal padding, so any padded element that wrapped was measured one or more lines too short (#39). Both now wrap at the same effective width. Table row heights are computed from `get_height`, so padded cells in narrow columns no longer draw text outside their cell rectangle, and page breaks — which compare the measured row height against the remaining space — are decided from the height that actually gets drawn.
+- Dynamic font sizing (`fontSize: { min, max, fit }`) fitted text to the unpadded box for the same reason, picking a size that overflowed. It now sizes against the padded box.
+
 ### Added
 - Table columns can now declare fixed and flexible widths, not just percentages. A column's `width` accepts `25` / `"25mm"` (fixed millimetres), `"20%"` (share of the table width), and `"2fr"` / `"fr"` (share of the leftover width, like CSS grid). Fixed and percent columns are placed first and the remainder is split between the `fr` columns by weight.
 - Rows whose cell count does not match the column count are now rejected at parse time with the offending row index, instead of panicking mid-render.

--- a/src/schemas/text.rs
+++ b/src/schemas/text.rs
@@ -582,13 +582,16 @@ impl Text {
     }
     pub fn get_height(&self) -> Result<Mm, Error> {
         let font_size = self.get_font_size()?;
+        // Must be the same width `render` wraps at, or the reported height does
+        // not describe what actually gets drawn.
+        let (box_width, _) = self.get_effective_box_size();
 
         let lines: Vec<String> = self
             .font_spec
             .split_text_to_size(
                 &self.content,
                 font_size,
-                self.base.width.into(),
+                box_width.into(),
                 self.character_spacing,
             )
             .context(FontSnafu)?;
@@ -602,17 +605,22 @@ impl Text {
     fn get_font_size(&self) -> Result<Pt, Error> {
         match self.font_size.clone() {
             FontSize::Fixed(font_size) => Ok(font_size),
-            FontSize::Dynamic(dynamic_font_size) => self
-                .font_spec
-                .calculate_dynamic_font_size(
-                    dynamic_font_size,
-                    self.line_height,
-                    self.character_spacing,
-                    self.base.width,
-                    self.base.height,
-                    &self.content,
-                )
-                .context(FontSnafu),
+            FontSize::Dynamic(dynamic_font_size) => {
+                // Auto-sizing fits text to a box, and the box text is drawn into
+                // is the padded one — sizing against the full box picks a font
+                // that overflows.
+                let (box_width, box_height) = self.get_effective_box_size();
+                self.font_spec
+                    .calculate_dynamic_font_size(
+                        dynamic_font_size,
+                        self.line_height,
+                        self.character_spacing,
+                        box_width,
+                        box_height,
+                        &self.content,
+                    )
+                    .context(FontSnafu)
+            }
         }
     }
 }
@@ -718,6 +726,102 @@ mod tests {
         let mut font_map = FontMap::default();
         font_map.add_font("TestFont".to_string(), font_id, parsed_font.as_ref());
         font_map
+    }
+
+    /// A padded `Text` whose content wraps. `render` lays this out inside
+    /// `base.width` minus the horizontal padding, so anything that measures the
+    /// element has to wrap at the same width.
+    fn padded_wrapping_text() -> Text {
+        let font_map = test_font_map();
+        Text::new(
+            Mm(0.0),
+            Mm(0.0),
+            Mm(20.0),
+            Mm(0.0),
+            "TestFont".to_string(),
+            Pt(10.0),
+            "20mm fixed".to_string(),
+            Alignment::Left,
+            VerticalAlignment::Top,
+            &font_map,
+            Some(Frame {
+                top: Mm(1.0),
+                right: Mm(5.0),
+                bottom: Mm(1.0),
+                left: Mm(5.0),
+            }),
+        )
+        .unwrap()
+    }
+
+    /// How many lines `render` will actually draw.
+    fn rendered_line_count(text: &Text) -> usize {
+        let font_size = text.get_font_size().unwrap();
+        let (box_width, _) = text.get_effective_box_size();
+        text.font_spec
+            .split_text_to_size(
+                &text.content,
+                font_size,
+                box_width.into(),
+                text.character_spacing,
+            )
+            .unwrap()
+            .len()
+    }
+
+    #[test]
+    fn get_height_wraps_at_the_same_width_render_does() {
+        let text = padded_wrapping_text();
+
+        let lines = rendered_line_count(&text);
+        assert!(
+            lines > 1,
+            "fixture should wrap; got {lines} line(s) — pick narrower content"
+        );
+
+        let font_size = Pt(10.0);
+        let line_height = text.line_height.unwrap_or(1.0);
+        let content_height: Mm = Pt(lines as f32 * font_size.0 * line_height).into();
+        let expected = content_height + Mm(1.0) + Mm(1.0); // vertical padding
+
+        let measured = text.get_height().unwrap();
+        assert!(
+            (measured.0 - expected.0).abs() < 1e-3,
+            "get_height reported {measured:?} but render draws {lines} lines needing {expected:?}"
+        );
+    }
+
+    #[test]
+    fn get_height_accounts_for_horizontal_padding() {
+        // Same element, same content: widening the horizontal padding leaves less
+        // room for text, so the measured height can only grow.
+        let narrow_padding = padded_wrapping_text();
+
+        let font_map = test_font_map();
+        let wide_padding = Text::new(
+            Mm(0.0),
+            Mm(0.0),
+            Mm(20.0),
+            Mm(0.0),
+            "TestFont".to_string(),
+            Pt(10.0),
+            "20mm fixed".to_string(),
+            Alignment::Left,
+            VerticalAlignment::Top,
+            &font_map,
+            Some(Frame {
+                top: Mm(1.0),
+                right: Mm(8.0),
+                bottom: Mm(1.0),
+                left: Mm(8.0),
+            }),
+        )
+        .unwrap();
+
+        assert!(
+            wide_padding.get_height().unwrap() > narrow_padding.get_height().unwrap(),
+            "wider horizontal padding must not measure shorter"
+        );
     }
 
     // Simplified tests that focus on testing individual methods without requiring full Text construction

--- a/src/schemas/text.rs
+++ b/src/schemas/text.rs
@@ -791,6 +791,105 @@ mod tests {
         );
     }
 
+    /// Auto-sized text with the given padding. `fit` is `"horizontal"` or
+    /// `"vertical"`; everything else is held constant so the padding is the only
+    /// variable between fixtures.
+    fn auto_sized_text(fit: &str, padding: Option<(f32, f32)>) -> Text {
+        let font_map = test_font_map();
+        let mut value = json!({
+            "name": "auto",
+            "position": { "x": 0.0, "y": 0.0 },
+            "width": 40.0,
+            "height": 20.0,
+            "content": "Auto sized text that wraps",
+            "fontName": "TestFont",
+            "fontSize": { "min": 4.0, "max": 40.0, "fit": fit }
+        });
+        if let Some((horizontal, vertical)) = padding {
+            value["padding"] = json!({
+                "top": vertical,
+                "right": horizontal,
+                "bottom": vertical,
+                "left": horizontal,
+            });
+        }
+
+        let json: JsonTextSchema = serde_json::from_value(value).unwrap();
+        Text::from_json(json, &font_map).unwrap()
+    }
+
+    #[test]
+    fn horizontal_auto_sizing_fits_the_padded_box() {
+        // Auto-sizing grows the font until the text fills the box. Padding
+        // shrinks that box, so it has to pick a smaller size — sizing against
+        // the unpadded box yields text too wide for the space it is drawn in.
+        let unpadded = auto_sized_text("horizontal", None).get_font_size().unwrap();
+        let padded = auto_sized_text("horizontal", Some((8.0, 1.0)))
+            .get_font_size()
+            .unwrap();
+
+        assert!(
+            padded < unpadded,
+            "horizontal padding must shrink the auto size: padded {padded:?} vs unpadded {unpadded:?}"
+        );
+    }
+
+    #[test]
+    fn vertical_auto_sizing_fits_the_padded_box() {
+        // Same argument on the other axis: the shrink test compares against the
+        // box height, which padding also reduces.
+        let unpadded = auto_sized_text("vertical", None).get_font_size().unwrap();
+        let padded = auto_sized_text("vertical", Some((1.0, 6.0)))
+            .get_font_size()
+            .unwrap();
+
+        assert!(
+            padded < unpadded,
+            "vertical padding must shrink the auto size: padded {padded:?} vs unpadded {unpadded:?}"
+        );
+    }
+
+    #[test]
+    fn auto_sized_text_stays_inside_its_padded_box() {
+        // The end-to-end property the two tests above serve: whatever size is
+        // chosen, the laid-out text must fit the box render actually uses.
+        for fit in ["horizontal", "vertical"] {
+            let text = auto_sized_text(fit, Some((8.0, 3.0)));
+            let font_size = text.get_font_size().unwrap();
+            let (box_width, box_height) = text.get_effective_box_size();
+
+            let lines = text
+                .font_spec
+                .split_text_to_size(
+                    &text.content,
+                    font_size,
+                    box_width.into(),
+                    text.character_spacing,
+                )
+                .unwrap();
+
+            let line_height = text.line_height.unwrap_or(1.0);
+            let content_height: Mm = Pt(lines.len() as f32 * font_size.0 * line_height).into();
+            assert!(
+                content_height <= box_height,
+                "fit={fit}: {} line(s) at {font_size:?} need {content_height:?} in a {box_height:?} box",
+                lines.len()
+            );
+
+            for line in &lines {
+                let width: Mm = text
+                    .font_spec
+                    .width_of_text_at_size(line, font_size, text.character_spacing)
+                    .unwrap()
+                    .into();
+                assert!(
+                    width <= box_width,
+                    "fit={fit}: line {line:?} is {width:?} wide in a {box_width:?} box"
+                );
+            }
+        }
+    }
+
     #[test]
     fn get_height_accounts_for_horizontal_padding() {
         // Same element, same content: widening the horizontal padding leaves less


### PR DESCRIPTION
Closes #39.

## The defect

`Text::get_height` wrapped text at the full `base.width`, while `Text::render` wraps at `get_effective_box_size()` — `base.width` minus horizontal padding. Any padded element whose text wrapped was measured short.

Measured with a 20mm-wide element, 5mm side padding, 10pt font, content `"20mm fixed"`:

```
base.width = 20mm   effective box_width = 10mm
get_height wraps to 2 line(s): ["20mm ", "fixed"]
render     wraps to 3 line(s): ["20m", "m ", "fixed"]
get_height() = Mm(9.06)     // render needs 12.58mm
```

## Why it matters

Table row height is the max of the cells' `get_height`, and the stock table styles carry cell padding — so a narrow column's text was drawn outside its cell rectangle. Page breaks compare that same measured height against the remaining space, so rows could also be placed where they did not actually fit.

`templates/large-tables-spanning.json` shows both failures at once. Its inventory table header has `Unit Price` and `Total Value` in ~12% columns, which wrap to two lines once padding is accounted for:

- **Before** — the header was measured as one line, so it was judged to fit at the bottom of page 3. It was drawn there with a header band sized for one line, and the second line of both labels spilled out past the purple background.
- **After** — the header measures two lines. It no longer fits in the remaining space, so the page-break logic carries the whole table to page 4, where the header band is tall enough to contain the wrapped labels.

Page count is unchanged at 5.

## Same cause, second site

`get_font_size` passed the unpadded box to `calculate_dynamic_font_size`, so `fontSize: { min, max, fit }` fitted text to a box larger than the one it is drawn into — auto-sized text overflowed for the same reason. A 40x20mm element with 8mm side padding picked 18.75pt, producing five lines needing 33mm of a 14mm box.

Both sites now derive their width from `get_effective_box_size`, the single place that already computed it.

## Tests

Five new tests. Each was confirmed to fail against the unfixed code and pass with it — including the auto-sizing ones, which is how the gap below was caught.

Measurement:
- `get_height_wraps_at_the_same_width_render_does` — pins the measured height to the line count `render` actually produces
- `get_height_accounts_for_horizontal_padding` — widening horizontal padding must never measure shorter

Auto-sizing (`FontSize::Dynamic`):
- `horizontal_auto_sizing_fits_the_padded_box` — padding must strictly shrink the chosen size
- `vertical_auto_sizing_fits_the_padded_box` — same on the vertical axis
- `auto_sized_text_stays_inside_its_padded_box` — for both fit modes, re-lays out at the chosen size and asserts the result fits the box `render` uses (total line height within `box_height`, every line within `box_width`)

The first two commits' tests all used a fixed font size, so they never reached the `FontSize::Dynamic` branch — reverting that half of the fix left them green. The three auto-sizing tests exist to close that. The vertical one initially asserted `padded <= unpadded`, which also passes unfixed; it is now strict.

Fixtures go through `Text::from_json` with a real font, not mocks, so they exercise the same path templates do.

## Verification

| Check | Result |
|---|---|
| `cargo test` | 127 passed / 0 failed (5 new) |
| `cargo fmt --check` | pass |
| clippy | no new warnings |
| Examples | quote, table-50pages, memory-efficient-table, pawn-tag, inventory_tag all ok |

Rendered output was diffed against `main` across 7 table templates. Six are byte-identical — their cells either have no horizontal padding or do not wrap, so their measurement was already correct. Only `large-tables-spanning.json` changes, and that change is the fix.

The two flow-cursor tests that assert positions derived from measured heights (`spacer_creates_exact_gap_between_flowing_tables`, `dynamic_text_spacer_and_table_share_one_flow_cursor`) still pass unmodified — their fixture content does not wrap, so its measurement is unaffected. Left as-is deliberately: they test the cursor contract between elements, not text wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)