### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-28
+
 ### Fixed
 - `Text::get_height` wrapped text at the full `base.width` while `Text::render` wraps at `base.width` minus horizontal padding, so any padded element that wrapped was measured one or more lines too short (#39). Both now wrap at the same effective width. Table row heights are computed from `get_height`, so padded cells in narrow columns no longer draw text outside their cell rectangle, and page breaks — which compare the measured row height against the remaining space — are decided from the height that actually gets drawn.
 - Dynamic font sizing (`fontSize: { min, max, fit }`) fitted text to the unpadded box for the same reason, picking a size that overflowed. It now sizes against the padded box.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -933,8 +933,12 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Recent Changes
 
-### Unreleased
+### Version 0.15.0
 - **Table Column Widths (breaking)**: `headWidthPercentages` is gone; column definitions are unified under `columns[]`, each entry carrying `width`, `header`, and `cell` (the `columns[].schema` wrapper is removed). A column's `width` now accepts fixed millimetres (`25`, `"25mm"`), percentages (`"20%"`), and leftover shares (`"2fr"`, `"fr"`). Percentages no longer have to sum to 100. Rows whose cell count does not match the column count are rejected at parse time instead of panicking mid-render. See [CHANGELOG.md](CHANGELOG.md) for the migration example.
+- **Text Height Measurement**: `Text::get_height` wrapped text at the full element width while rendering wraps at the width minus horizontal padding, so padded elements that wrapped were measured too short — padded table cells in narrow columns drew text outside their cell, and page breaks were decided from the wrong height. Dynamic font sizing (`fontSize: { min, max, fit }`) had the same defect and picked sizes that overflowed. Both now measure against the padded box.
+
+### Version 0.14.0
+- **Font Collection Face Index**: `PDForgeBuilder::add_font_with_index` and `add_font_from_file_with_index` select a specific face inside a TrueType/OpenType Collection (`.ttc`/`.otc`). `add_font`/`add_font_from_file` continue to load face 0.
 
 ### Version 0.13.0
 - **Table Header Styling**: `headStyles` background, font color, character spacing, line height, and per-side border (`borderColor` + `Frame` `borderWidth`) are now applied to header rows. Previously these were parsed but ignored, and headers reused `bodyStyles.backgroundColor`.


### PR DESCRIPTION
Releases the changes accumulated on `main` since 0.14.0.

## Version

`0.14.0` → **`0.15.0`**. Two breaking changes to the table schema, so the minor bumps under 0.x semver — matching the repo's own precedent (0.13.0 carried breaking removals as a minor bump).

## What ships

### Breaking — table column definitions (#38)

`headWidthPercentages` is removed. Column definitions are unified under `columns[]`, each entry carrying `width`, `header`, and `cell`; the `columns[].schema` wrapper is gone.

```json
// before
"headWidthPercentages": [
  { "content": "Name", "percent": 70 },
  { "content": "Price", "percent": 30 }
],
"columns": [
  { "schema": { "type": "text", "name": "name",  "...": "..." } },
  { "schema": { "type": "text", "name": "price", "...": "..." } }
]

// after
"columns": [
  { "width": "70%", "header": { "content": "Name" },  "cell": { "type": "text", "name": "name",  "...": "..." } },
  { "width": "30%", "header": { "content": "Price" }, "cell": { "type": "text", "name": "price", "...": "..." } }
]
```

A percentage `N` migrates to `"N%"` unchanged.

### Breaking — column widths no longer have to sum to 100% (#38)

`width` now accepts fixed millimetres (`25`, `"25mm"`), percentages (`"20%"`), and leftover shares (`"2fr"`, `"fr"`). Widths that fall short leave the table narrower than declared; widths that overflow are scaled down to fit. Neither is an error.

### Fixed — text height measurement (#39, #40)

`Text::get_height` wrapped at the full element width while `render` wraps at the width minus horizontal padding, so padded elements that wrapped were measured too short. Padded table cells in narrow columns drew text outside their cell rectangle, and page breaks were decided from the wrong height. Dynamic font sizing had the same defect and picked sizes that overflowed.

**This changes rendered output** for templates with padded cells whose text wraps — row heights grow to their true size, which can move rows to a later page. `templates/large-tables-spanning.json` is the one bundled template affected.

## Also in this PR

The README "Recent Changes" section had no entry for 0.14.0 — the previous release did not add one. Filled in alongside the 0.15.0 entry.

## Verification

| Check | Result |
|---|---|
| `cargo test` | 127 passed / 0 failed |
| `cargo build` | clean |
| `Cargo.toml` / `Cargo.lock` | both at 0.15.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)