### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-28
+
 ### Fixed
 - The half-width space's advance width was read from `ParsedFont::space_width`, which upstream (printpdf 0.12.3 / azul-layout 0.0.12) computes during `from_bytes_internal`, before the font's source bytes are attached — for every byte-parsed face it caches `Some(0)`. A `0` tripped `width_of_text_at_size`'s zero-width fallback, so each space was charged the 500-unit tofu (replacement-glyph) width instead of the font's real `hmtx` advance (224 units for NotoSansJP), over-measuring every space by roughly 2.76pt at 10pt. Any line containing spaces was measured wider than it would actually draw, so it wrapped before its box was full. Space width is now read through the same `lookup_glyph_index` → `get_horizontal_advance` path the renderer draws from, so measurement and rendering agree.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "pdforge"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdforge"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -937,6 +937,9 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Recent Changes
 
+### Version 0.17.0
+- **Space Width Measurement (behavior change)**: the half-width space was measured at the 500-unit tofu (replacement-glyph) width rather than the font's real `hmtx` advance, because `ParsedFont::space_width` reads back `0` for every byte-parsed face. Any line containing spaces measured wider than it would draw and wrapped before its box was full — roughly 2.76pt of phantom width per space at 10pt with NotoSansJP. Space width now comes from the same `hmtx` advance the renderer draws from. Existing templates whose text contains spaces will re-flow: more text fits per line, so row heights shrink, page breaks move, and vertical/horizontal alignment and dynamic font sizing shift with the corrected width.
+
 ### Version 0.16.0
 - **Table Horizontal Position (behavior change)**: a table's `position.x` was silently raised to `basePdf.padding.left`, and its available width was computed from the page padding rather than from where the table starts — a table at `x: 10` with `padding: [10, 10, 20, 20]` rendered at `x: 20`, 180mm wide instead of 190mm. `position.x` is now honoured as an absolute coordinate, matching every other schema type and the table's own vertical axis. `width` is a maximum, trimmed to `page width - padding.right` rather than the table being slid left. Templates that relied on the old clamping will render differently.
 - **`basePdf.padding` semantics documented per side**: `top`/`bottom` bound pagination, `right` bounds a table's maximum width, `left` is not consulted by any schema.


### PR DESCRIPTION
Releases the space-width measurement fix from #44.

## Why minor, not patch

No API or schema change — but the fix re-flows text in **every template whose content contains spaces**. Lines now measure at the font's real `hmtx` advance instead of the 500-unit tofu width, so more text fits per line, table row heights shrink, page-break decisions move (a multi-page document can lose a page), and vertical/horizontal alignment and `fontSize: { min, max, fit }` all shift with the corrected width.

That is the same call 0.16.0 made:

> No API or schema change, but a layout shift is not something to ship in a patch, so the minor bumps.

If anything the case is stronger here: 0.16.0's shift reached one of the 16 templates in `templates/`, this one reaches any template with a space in it. On `0.x`, cargo treats only `0.17.x` as compatible with `0.17.0`, so existing users pick this up deliberately rather than through a patch-range update.

## Contents

- `CHANGELOG.md` — `[Unreleased]` promoted to `[0.17.0] - 2026-07-28`
- `README.md` — Recent Changes entry
- `Cargo.toml` / `Cargo.lock` — 0.16.0 → 0.17.0

`cargo test`: 139 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)