### PR TITLE
feat: add rotate support to QR Code schema

### DIFF
--- a/docs/qrcode-rotate-implementation-plan.md
+++ b/docs/qrcode-rotate-implementation-plan.md
@@ -1,0 +1,380 @@
+# QR Code `rotate` Implementation Plan
+
+## Overview
+
+Enable `rotate` field support for QR Code schema, consistent with existing rotation behavior in `Group`, `Rectangle`, and `Line` schemas.
+
+## Requirements
+
+- **Pivot Point**: Center of QR code image (matches Group/Rect/Line behavior: center of the element's bounding box)
+- **Unit**: Degrees (`f32`)
+- **Behavior**: No clipping — rotated QR code should remain centered in its allocated space
+
+## Files to Change
+
+| File | Purpose |
+|---|---|
+| `src/schemas/base.rs` | Add new `get_matrix_with_rotation()` helper; keep original 2-arg `get_matrix()` (non-breaking) |
+| `src/schemas/image.rs` | Keep original 2-arg `get_matrix()` — no rotation |
+| `src/schemas/svg.rs` | Keep original 2-arg `get_matrix()` — no rotation |
+| `src/schemas/qrcode.rs` | Use `get_matrix_with_rotation()` with `Some(XObjectRotation)` when `rotate` set |
+| `templates/qrcode-rotate-test.json` | New test template |
+| `examples/qrcode-rotate-test.rs` | New example runner |
+| `tests/qr_code_rotation_test.rs` | New auto-test suite |
+
+## Current State
+
+- `JsonQrCodeSchema` has `rotate: Option<f32>` (line 18)
+- `QrCode` struct stores `rotate: Option<f32>` (line 28)
+- `render()` previously ignored `rotate` entirely; it used `BaseSchema::get_matrix()` which had no rotation parameter
+- `BaseSchema::get_matrix()` previously built `XObjectTransform` with fixed `rotate: None`
+
+```rust
+pub fn get_matrix(&self, page_height: Mm, original_width: Option<Px>) -> XObjectTransform {
+    XObjectTransform {
+        translate_x: Some(self.x.into()),
+        translate_y: Some((page_height - self.y - self.height).into()),
+        rotate: None,  // <-- always None
+        scale_x: Some(ratio * self.width.0),
+        scale_y: Some(ratio * self.height.0),
+        dpi: Some(dpi),
+        no_auto_scale: false,
+    }
+}
+```
+
+## Dismissed Approaches
+
+### ~~Option B (Original): Center-Pivot via CTM~~
+
+**DISCARDED** due to blockers:
+
+1. **Double translation**: `calculate_transform_matrix_with_center_pivot` already includes x/y translation, and `UseXobject`'s `transform` also contains absolute coordinates. Combining both applies translation twice.
+2. **Incorrect tx/ty formula**: The original formula expressions are wrong.
+3. **Unnecessary complexity**: `printpdf::XObjectTransform.rotate` already supports center-specifiable rotation.
+
+## Implementation (Final): Non-breaking — add `get_matrix_with_rotation`
+
+**Codex review (REQUEST CHANGES)** flagged that changing `get_matrix()`'s signature is a breaking public-API change. Final approach keeps the original 2-arg `get_matrix()` untouched and adds a new `get_matrix_with_rotation()` helper that the original delegates to with `rotation = None`.
+
+### Call Sites
+
+Current `get_matrix()` / `get_matrix_with_rotation()` callers:
+1. `svg.rs` — uses basic `get_matrix()` (no rotation)
+2. `image.rs` — uses basic `get_matrix()` (no rotation)
+3. `qrcode.rs` — uses `get_matrix_with_rotation()` (rotation when `rotate` set)
+
+Only 3 call sites; all are image-like schemas that will need rotation eventually.
+
+### Rationale
+
+- `printpdf` 0.12.3's `XObjectTransform.rotate` expects `XObjectRotation` (not `Angle`)
+- `XObjectRotation` has fields:
+  - `angle_ccw_degrees: f32`
+  - `rotation_center_x: Px`
+  - `rotation_center_y: Px`
+- Rotation center is specified **in pixels relative to the image XObject's intrinsic size**
+- `BaseSchema` cannot compute its own rotation center — it only has layout dimensions, not image dimensions; each caller must provide it based on their actual XObject size
+- Passing `Option<XObjectRotation>` centralizes rotation logic in one place while keeping callers in charge of rotation center
+- When Image/SVG add rotation support later, just add `rotate` field to their schema and pass `XObjectRotation` to `get_matrix()` — no CTM duplication
+
+### Code Change (`src/schemas/base.rs`)
+
+```rust
+// Existing public 2-arg API — unchanged (non-breaking)
+pub fn get_matrix(&self, page_height: Mm, original_width: Option<Px>) -> XObjectTransform {
+    self.get_matrix_with_rotation(page_height, original_width, None)
+}
+
+// New helper centralizing rotation logic
+pub fn get_matrix_with_rotation(
+    &self,
+    page_height: Mm,
+    original_width: Option<Px>,
+    rotation: Option<XObjectRotation>,
+) -> XObjectTransform {
+    let dpi: f32 = 300.0;
+    let ratio: f32 = match original_width {
+        Some(original_width) => dpi / 25.4 / (original_width.0 as f32),
+        None => 1.0,
+    };
+    XObjectTransform {
+        translate_x: Some(self.x.into()),
+        translate_y: Some((page_height - self.y - self.height).into()),
+        rotate: rotation,
+        scale_x: Some(ratio * self.width.0),
+        scale_y: Some(ratio * self.height.0),
+        dpi: Some(dpi),
+        no_auto_scale: false,
+    }
+}
+```
+
+### Code Change (`src/schemas/svg.rs`)
+
+Keeps original 2-arg call — no rotation for SVG:
+
+```rust
+let transform = self.base.get_matrix(parent_height, self.content.width);
+```
+
+### Code Change (`src/schemas/image.rs`)
+
+`calculate_object_fit_transform` for Fill mode keeps the original 2-arg call:
+
+```rust
+self.base.get_matrix(parent_height, Some(Px(image.width)))
+```
+
+Other object-fit modes already construct their own `XObjectTransform`; update them to keep `rotate: None`:
+
+```rust
+XObjectTransform {
+    // ... existing translate_x/y, scale_x/y, etc.
+    rotate: None,  // explicitly None; future Image rotation support would set this
+```
+
+### Code Change (`src/schemas/qrcode.rs::render()`)
+
+Apply rotation **after** alignment + padding placement. Use actual QR image dimensions `w/h` for rotation center:
+
+```rust
+use printpdf::{XObjectTransform, XObjectRotation};
+
+let rotation: Option<XObjectRotation> = self.rotate.map(|angle_deg| XObjectRotation {
+    angle_ccw_degrees: angle_deg,
+    rotation_center_x: Px(w as usize / 2),
+    rotation_center_y: Px(h as usize / 2),
+});
+
+let transform = temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_width), rotation);
+```
+
+**Key properties:**
+
+- `rotation_center_x/y` in image pixel coordinates; `Px(w as usize / 2)` and `Px(h as usize / 2)` place pivot at image center
+- `Px(pub usize)` requires `usize`, not `f32`
+- Rotation logic centralized in `BaseSchema::get_matrix_with_rotation()`
+- Image/SVG rotation support is just: add `rotate` field, compute rotation from image w/h, pass to `get_matrix_with_rotation()`
+- `qrcode_width` uses the **actual intrinsic image width** `Px(w as usize)` (not a hardcoded `Px(256)`), fixing the ~3.1% overscaling bug
+
+## Test Strategy
+
+1. **Visual Verification**:
+   - Generate QR with `rotate: 30`, `rotate: 45`, `rotate: 90`, `rotate: 360`
+   - Confirm: box-level center is the rotation pivot; QR code rotates inside bounding box
+   - Confirm: with `align` = Left/Center/Right + `v_align` = Top/Middle/Bottom + `padding` present — rotated QR stays correctly positioned
+
+2. **Auto-tests (REQUIRED)**:
+   - `rotate: None` → `Op::UseXobject.transform.rotate == None` (identical to current no-rotation behavior)
+   - `rotate: 90` → `transform.rotate` center set to actual image center `(w/2, h/2)` (w/h from generated QR, e.g. 264 → 132)
+   - `get_matrix()` keeps original 2-arg signature; `get_matrix_with_rotation(.., None)` matches original
+   - Rotation direction matches Group/Rect direction at same angle
+   - Scale regression: with `original_width` = intrinsic image width, `scale_x` matches `300/25.4/w*width`
+   - Tests use table cell + padding + various alignment combinations
+
+3. **Code Validation**:
+   - Build: `cargo build --quiet`
+   - Test: `cargo test`
+   - Example: `cargo run --example qrcode-rotate-test`
+
+## New Assets
+
+### 1. `/templates/qrcode-rotate-test.json`
+
+Tests QR codes in table cells with observable padding and different alignment values.
+Uses current `JsonTableSchema` structure:
+- `JsonFrame` is object form `{top, right, bottom, left}`, not array `[..]`
+- Each QR cell has directly specified content and padding; bodyStyles.padding is NOT inherited by QR cells
+- First column uses height=60 QR to set row max height, so subsequent height=40 QRs have visible whitespace for padding/alignment verification
+- table height=100 < page height=150
+
+```jsonc
+{
+  "schemas": [
+    [
+      {
+        "type": "table",
+        "name": "test_table",
+        "position": { "x": 10, "y": 10 },
+        "width": 190,
+        "height": 100,
+        "showHead": true,
+        "headStyles": {
+          "fontSize": 8,
+          "fontName": "NotoSansJP",
+          "alignment": "center",
+          "verticalAlignment": "middle",
+          "lineHeight": 1.0,
+          "fontColor": "#000000",
+          "borderColor": "#000000",
+          "backgroundColor": "#f0f0f0",
+          "borderWidth": {
+            "top": 0.2,
+            "right": 0.2,
+            "bottom": 0.2,
+            "left": 0.2
+          },
+          "padding": {
+            "top": 2,
+            "right": 2,
+            "bottom": 2,
+            "left": 2
+          }
+        },
+        "bodyStyles": {
+          "alignment": "center",
+          "verticalAlignment": "middle",
+          "lineHeight": 1.0,
+          "fontColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "padding": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "lineBreakMode": "char"
+        },
+        "tableStyles": {
+          "borderWidth": 0.2,
+          "borderColor": "#000000"
+        },
+        "columns": [
+          {
+            "width": "3fr",
+            "header": { "content": "no rotate (60)" },
+            "cell": {
+              "type": "qrCode",
+              "name": "no_rotate",
+              "content": "qr_rotate_test_no_rotate",
+              "position": { "x": 0, "y": 0 },
+              "width": 45,
+              "height": 60,
+              "alignment": "center",
+              "verticalAlignment": "middle"
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 30 center" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_30_center",
+              "content": "qr_rotate_test_30_center",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 30,
+              "alignment": "center",
+              "verticalAlignment": "middle",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 90 top" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_90_top",
+              "content": "qr_rotate_test_90_top",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 90,
+              "alignment": "left",
+              "verticalAlignment": "top",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 90 bottom" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_90_bottom",
+              "content": "qr_rotate_test_90_bottom",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 90,
+              "alignment": "left",
+              "verticalAlignment": "bottom",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          }
+        ],
+        "fields": [
+          ["", "", "", ""]
+        ]
+      }
+    ]
+  ],
+  "basePdf": {
+    "width": 210,
+    "height": 150,
+    "padding": [10, 10, 10, 10]
+  },
+  "schemaVersion": "1.0.0"
+}
+```
+
+### 2. `/examples/qrcode-rotate-test.rs`
+
+```rust
+use std::collections::HashMap;
+use pdforge::PDForgeBuilder;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pdforge = PDForgeBuilder::new("QR Code Rotation Test".to_string())
+        .add_font_from_file("NotoSansJP", "./assets/fonts/NotoSansJP-Regular.ttf")?
+        .load_template("qr_rotate", "./templates/qrcode-rotate-test.json")?
+        .build();
+
+    let bytes = pdforge.render("qr_rotate", vec![vec![HashMap::new()]], None, None)?;
+
+    std::fs::create_dir_all("examples/pdf").ok();
+    std::fs::write("examples/pdf/qrcode-rotate-test.pdf", bytes)?;
+
+    println!("PDF generated: examples/pdf/qrcode-rotate-test.pdf");
+    Ok(())
+}
+```
+
+### 3. `/tests/qr_code_rotation_test.rs`
+
+Auto-test covering:
+- `rotate: None` → transform unchanged (no rotation applied)
+- `rotate: Some(90.0)` → transform has `rotate: Some(XObjectRotation { angle_ccw_degrees: 90.0, rotation_center_x: Px(w/2), rotation_center_y: Px(h/2) })`
+- Rotation direction and center match Group/Rect behavior
+
+## Change Checklist
+
+- [x] Plan documented in `docs/qrcode-rotate-implementation-plan.md`
+- [x] Approach: Extend `BaseSchema::get_matrix()` with optional `XObjectRotation` parameter
+- [x] Add rotation parameter to `BaseSchema::get_matrix()` in `src/schemas/base.rs`
+- [x] Update call sites: `svg.rs`, `image.rs` pass `None`
+- [x] Implement rotation logic in `src/schemas/qrcode.rs::render()` — construct `XObjectRotation` from `self.rotate` + image `w/h`
+- [x] Create test template + example (with HashMap import)
+- [x] Write auto-tests in `tests/qr_code_rotation_test.rs`
+- [x] `cargo build` / verify example + visual inspection
+- [x] `cargo test` passes
+
+---
+
+End of plan.

--- a/docs/qrcode-rotate-implementation-plan.md
+++ b/docs/qrcode-rotate-implementation-plan.md
@@ -136,15 +136,22 @@ XObjectTransform {
 
 ### Code Change (`src/schemas/qrcode.rs::render()`)
 
-Apply rotation **after** alignment + padding placement. Use actual QR image dimensions `w/h` for rotation center:
+Apply rotation **after** alignment + padding placement. `printpdf` composes the
+image and layout scales before applying the pivot, so express the center of the
+final QR square as pixels at the transform DPI:
 
 ```rust
 use printpdf::{XObjectTransform, XObjectRotation};
 
+let rotation_center = Px(
+    (qr_side.0 * XOBJECT_DPI / 25.4 / 2.0)
+        .round()
+        .max(0.0) as usize,
+);
 let rotation: Option<XObjectRotation> = self.rotate.map(|angle_deg| XObjectRotation {
     angle_ccw_degrees: angle_deg,
-    rotation_center_x: Px(w as usize / 2),
-    rotation_center_y: Px(h as usize / 2),
+    rotation_center_x: rotation_center,
+    rotation_center_y: rotation_center,
 });
 
 let transform = temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_width), rotation);
@@ -152,7 +159,7 @@ let transform = temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_wi
 
 **Key properties:**
 
-- `rotation_center_x/y` in image pixel coordinates; `Px(w as usize / 2)` and `Px(h as usize / 2)` place pivot at image center
+- `rotation_center_x/y` represent the final rendered QR center converted to pixels at `XOBJECT_DPI`; using the source image center would shift a scaled QR during rotation
 - `Px(pub usize)` requires `usize`, not `f32`
 - Rotation logic centralized in `BaseSchema::get_matrix_with_rotation()`
 - Image/SVG rotation support is just: add `rotate` field, compute rotation from image w/h, pass to `get_matrix_with_rotation()`
@@ -167,7 +174,7 @@ let transform = temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_wi
 
 2. **Auto-tests (REQUIRED)**:
    - `rotate: None` → `Op::UseXobject.transform.rotate == None` (identical to current no-rotation behavior)
-   - `rotate: 90` → `transform.rotate` center set to actual image center `(w/2, h/2)` (w/h from generated QR, e.g. 264 → 132)
+   - `rotate: 90` → the final CTM has the same bounds as the unrotated QR at the same position and size
    - `get_matrix()` keeps original 2-arg signature; `get_matrix_with_rotation(.., None)` matches original
    - Rotation direction matches Group/Rect direction at same angle
    - Scale regression: with `original_width` = intrinsic image width, `scale_x` matches `300/25.4/w*width`
@@ -186,7 +193,10 @@ Tests QR codes in table cells with observable padding and different alignment va
 Uses current `JsonTableSchema` structure:
 - `JsonFrame` is object form `{top, right, bottom, left}`, not array `[..]`
 - Each QR cell has directly specified content and padding; bodyStyles.padding is NOT inherited by QR cells
-- First column uses height=60 QR to set row max height, so subsequent height=40 QRs have visible whitespace for padding/alignment verification
+- First column uses height=60 to set the row height while every QR renders as a
+  40 mm square; the remaining whitespace makes vertical alignment observable
+- Rotated cells use 2 mm padding, which fits around the 40 mm QR without changing
+  its rendered size
 - table height=100 < page height=150
 
 ```jsonc
@@ -243,13 +253,13 @@ Uses current `JsonTableSchema` structure:
         "columns": [
           {
             "width": "3fr",
-            "header": { "content": "no rotate (60)" },
+            "header": { "content": "no rotate (40 square)" },
             "cell": {
               "type": "qrCode",
               "name": "no_rotate",
               "content": "qr_rotate_test_no_rotate",
               "position": { "x": 0, "y": 0 },
-              "width": 45,
+              "width": 40,
               "height": 60,
               "alignment": "center",
               "verticalAlignment": "middle"
@@ -257,64 +267,64 @@ Uses current `JsonTableSchema` structure:
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 30 center" },
+            "header": { "content": "rotate: 30 (40 square)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_30_center",
               "content": "qr_rotate_test_30_center",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 30,
               "alignment": "center",
               "verticalAlignment": "middle",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 90 top" },
+            "header": { "content": "rotate: 90 top (40)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_90_top",
               "content": "qr_rotate_test_90_top",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 90,
               "alignment": "left",
               "verticalAlignment": "top",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 90 bottom" },
+            "header": { "content": "rotate: 90 bottom (40)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_90_bottom",
               "content": "qr_rotate_test_90_bottom",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 90,
               "alignment": "left",
               "verticalAlignment": "bottom",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           }
@@ -360,7 +370,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Auto-test covering:
 - `rotate: None` → transform unchanged (no rotation applied)
-- `rotate: Some(90.0)` → transform has `rotate: Some(XObjectRotation { angle_ccw_degrees: 90.0, rotation_center_x: Px(w/2), rotation_center_y: Px(h/2) })`
+- `rotate: Some(90.0)` → the transform rotates around the center of the final rendered QR square without changing its bounds
 - Rotation direction and center match Group/Rect behavior
 
 ## Change Checklist

--- a/examples/qrcode-rotate-same-size.rs
+++ b/examples/qrcode-rotate-same-size.rs
@@ -1,0 +1,23 @@
+use pdforge::PDForgeBuilder;
+use std::collections::HashMap;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pdforge = PDForgeBuilder::new("QR Code 90 Degree Rotation".to_string())
+        .add_font_from_file("NotoSansJP", "./assets/fonts/NotoSansJP-Regular.ttf")?
+        .load_template(
+            "qr_rotate_same_size",
+            "./templates/qrcode-rotate-same-size.json",
+        )?
+        .build();
+
+    let inputs = vec![vec![HashMap::new()], vec![HashMap::new()]];
+    let bytes = pdforge.render("qr_rotate_same_size", inputs, None, None)?;
+
+    std::fs::create_dir_all("examples/pdf").ok();
+    std::fs::write("examples/pdf/qrcode-rotate-same-size.pdf", bytes)?;
+
+    println!("PDF generated: examples/pdf/qrcode-rotate-same-size.pdf");
+    println!("Pages 1 and 2 use the same QR content, position, and 80 mm square size.");
+    println!("Only page 2 applies a 90 degree rotation around the QR center.");
+    Ok(())
+}

--- a/examples/qrcode-rotate-test.rs
+++ b/examples/qrcode-rotate-test.rs
@@ -1,0 +1,17 @@
+use pdforge::PDForgeBuilder;
+use std::collections::HashMap;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pdforge = PDForgeBuilder::new("QR Code Rotation Test".to_string())
+        .add_font_from_file("NotoSansJP", "./assets/fonts/NotoSansJP-Regular.ttf")?
+        .load_template("qr_rotate", "./templates/qrcode-rotate-test.json")?
+        .build();
+
+    let bytes = pdforge.render("qr_rotate", vec![vec![HashMap::new()]], None, None)?;
+
+    std::fs::create_dir_all("examples/pdf").ok();
+    std::fs::write("examples/pdf/qrcode-rotate-test.pdf", bytes)?;
+
+    println!("PDF generated: examples/pdf/qrcode-rotate-test.pdf");
+    Ok(())
+}

--- a/src/schemas/base.rs
+++ b/src/schemas/base.rs
@@ -1,4 +1,4 @@
-use printpdf::{Mm, Px, XObjectTransform};
+use printpdf::{Mm, Px, XObjectRotation, XObjectTransform};
 
 #[derive(Debug, Clone)]
 pub struct BaseSchema {
@@ -21,6 +21,15 @@ impl BaseSchema {
     }
 
     pub fn get_matrix(&self, page_height: Mm, original_width: Option<Px>) -> XObjectTransform {
+        self.get_matrix_with_rotation(page_height, original_width, None)
+    }
+
+    pub fn get_matrix_with_rotation(
+        &self,
+        page_height: Mm,
+        original_width: Option<Px>,
+        rotation: Option<XObjectRotation>,
+    ) -> XObjectTransform {
         let dpi: f32 = 300.0;
         let ratio: f32 = match original_width {
             Some(original_width) => dpi / 25.4 / (original_width.0 as f32),
@@ -30,7 +39,7 @@ impl BaseSchema {
         XObjectTransform {
             translate_x: Some(self.x.into()),
             translate_y: Some((page_height - self.y - self.height).into()),
-            rotate: None,
+            rotate: rotation,
             scale_x: Some(ratio * self.width.0),
             scale_y: Some(ratio * self.height.0),
             dpi: Some(dpi),

--- a/src/schemas/base.rs
+++ b/src/schemas/base.rs
@@ -1,5 +1,7 @@
 use printpdf::{Mm, Px, XObjectRotation, XObjectTransform};
 
+pub(crate) const XOBJECT_DPI: f32 = 300.0;
+
 #[derive(Debug, Clone)]
 pub struct BaseSchema {
     pub name: String,
@@ -30,7 +32,7 @@ impl BaseSchema {
         original_width: Option<Px>,
         rotation: Option<XObjectRotation>,
     ) -> XObjectTransform {
-        let dpi: f32 = 300.0;
+        let dpi = XOBJECT_DPI;
         let ratio: f32 = match original_width {
             Some(original_width) => dpi / 25.4 / (original_width.0 as f32),
 

--- a/src/schemas/qrcode.rs
+++ b/src/schemas/qrcode.rs
@@ -1,5 +1,8 @@
 use super::{Alignment, BoundingBox, Frame, VerticalAlignment};
-use crate::schemas::{base::BaseSchema, Error, HasBaseSchema, JsonPosition, Schema};
+use crate::schemas::{
+    base::{BaseSchema, XOBJECT_DPI},
+    Error, HasBaseSchema, JsonPosition, Schema,
+};
 use crate::utils::OpBuffer;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder, Luma};
@@ -157,9 +160,17 @@ impl QrCode {
         let image_x_object_id = doc.add_image(&image);
 
         // QRコードの実際のサイズを計算
+        // QRコードの縦横比は常に1:1。指定サイズと有効ボックスの両方に
+        // 収まる正方形とし、回転時も内容物のサイズを変えない。
         let (box_width, box_height) = self.get_effective_box_size();
-        let qr_width = self.base.width;
-        let qr_height = self.base.height;
+        let qr_side = self
+            .base
+            .width
+            .min(self.base.height)
+            .min(box_width)
+            .min(box_height);
+        let qr_width = qr_side;
+        let qr_height = qr_side;
 
         // 配置オフセットを計算
         let x_offset = self.calculate_horizontal_offset(box_width, qr_width);
@@ -184,11 +195,14 @@ impl QrCode {
         // 新しい基本スキーマを一時的に作成して、正しい位置に変換行列を取得
         let temp_base = BaseSchema::new(self.base.name.clone(), x, y, qr_width, qr_height);
 
-        // 回転中心は画像の実サイズの中心 (w/2, h/2)
+        // printpdf applies the image and layout scales before this pivot. Convert
+        // the center of the final QR square back to pixels at the transform DPI;
+        // using the source image's w/2,h/2 here would move a rotated, scaled QR.
+        let rotation_center = Px((qr_side.0 * XOBJECT_DPI / 25.4 / 2.0).round().max(0.0) as usize);
         let rotation: Option<XObjectRotation> = self.rotate.map(|angle_deg| XObjectRotation {
             angle_ccw_degrees: angle_deg,
-            rotation_center_x: Px(w as usize / 2),
-            rotation_center_y: Px(h as usize / 2),
+            rotation_center_x: rotation_center,
+            rotation_center_y: rotation_center,
         });
 
         let transform =

--- a/src/schemas/qrcode.rs
+++ b/src/schemas/qrcode.rs
@@ -3,7 +3,7 @@ use crate::schemas::{base::BaseSchema, Error, HasBaseSchema, JsonPosition, Schem
 use crate::utils::OpBuffer;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder, Luma};
-use printpdf::{Mm, Op, PdfDocument, Px, RawImage};
+use printpdf::{Mm, Op, PdfDocument, Px, RawImage, XObjectRotation};
 use serde::Deserialize;
 use snafu::ResultExt;
 
@@ -134,13 +134,13 @@ impl QrCode {
         page: usize,
         buffer: &mut OpBuffer,
     ) -> Result<(), Error> {
-        let qrcode_width = Px(256);
-
         let code =
             qrcode::QrCode::new(&self.content).whatever_context("Failed to create a QR code")?;
         let luma: image::ImageBuffer<Luma<u8>, Vec<u8>> = code.render::<Luma<u8>>().build();
         let w = luma.width();
         let h = luma.height();
+
+        let qrcode_width = Px(w as usize);
 
         let mut buf: Vec<u8> = Vec::new();
         let encoder: PngEncoder<&mut Vec<u8>> = PngEncoder::new(&mut buf);
@@ -184,7 +184,15 @@ impl QrCode {
         // 新しい基本スキーマを一時的に作成して、正しい位置に変換行列を取得
         let temp_base = BaseSchema::new(self.base.name.clone(), x, y, qr_width, qr_height);
 
-        let transform = temp_base.get_matrix(parent_height, Some(qrcode_width));
+        // 回転中心は画像の実サイズの中心 (w/2, h/2)
+        let rotation: Option<XObjectRotation> = self.rotate.map(|angle_deg| XObjectRotation {
+            angle_ccw_degrees: angle_deg,
+            rotation_center_x: Px(w as usize / 2),
+            rotation_center_y: Px(h as usize / 2),
+        });
+
+        let transform =
+            temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_width), rotation);
 
         let ops = vec![
             Op::SaveGraphicsState,
@@ -202,6 +210,10 @@ impl QrCode {
 
     pub fn set_bounding_box(&mut self, bounding_box: BoundingBox) {
         self.bounding_box = Some(bounding_box);
+    }
+
+    pub fn set_rotate(&mut self, rotate: f32) {
+        self.rotate = Some(rotate);
     }
 
     pub fn set_x(&mut self, x: Mm) {

--- a/templates/qrcode-rotate-same-size.json
+++ b/templates/qrcode-rotate-same-size.json
@@ -1,0 +1,61 @@
+{
+  "schemas": [
+    [
+      {
+        "type": "text",
+        "name": "title_unrotated",
+        "content": "Page 1: rotate omitted",
+        "position": { "x": 20, "y": 10 },
+        "width": 170,
+        "height": 10,
+        "fontSize": 10,
+        "fontName": "NotoSansJP",
+        "fontColor": "#000000",
+        "alignment": "center",
+        "verticalAlignment": "middle"
+      },
+      {
+        "type": "qrCode",
+        "name": "same_size_unrotated",
+        "content": "pdforge_qr_rotation_same_position_and_size",
+        "position": { "x": 65, "y": 35 },
+        "width": 80,
+        "height": 80,
+        "alignment": "center",
+        "verticalAlignment": "middle"
+      }
+    ],
+    [
+      {
+        "type": "text",
+        "name": "title_rotated",
+        "content": "Page 2: rotate 90 degrees",
+        "position": { "x": 20, "y": 10 },
+        "width": 170,
+        "height": 10,
+        "fontSize": 10,
+        "fontName": "NotoSansJP",
+        "fontColor": "#000000",
+        "alignment": "center",
+        "verticalAlignment": "middle"
+      },
+      {
+        "type": "qrCode",
+        "name": "same_size_rotated_90",
+        "content": "pdforge_qr_rotation_same_position_and_size",
+        "position": { "x": 65, "y": 35 },
+        "width": 80,
+        "height": 80,
+        "rotate": 90,
+        "alignment": "center",
+        "verticalAlignment": "middle"
+      }
+    ]
+  ],
+  "basePdf": {
+    "width": 210,
+    "height": 150,
+    "padding": [10, 10, 10, 10]
+  },
+  "schemaVersion": "1.0.0"
+}

--- a/templates/qrcode-rotate-test.json
+++ b/templates/qrcode-rotate-test.json
@@ -51,13 +51,13 @@
         "columns": [
           {
             "width": "3fr",
-            "header": { "content": "no rotate (60)" },
+            "header": { "content": "no rotate (40 square)" },
             "cell": {
               "type": "qrCode",
               "name": "no_rotate",
               "content": "qr_rotate_test_no_rotate",
               "position": { "x": 0, "y": 0 },
-              "width": 45,
+              "width": 40,
               "height": 60,
               "alignment": "center",
               "verticalAlignment": "middle"
@@ -65,64 +65,64 @@
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 30 center" },
+            "header": { "content": "rotate: 30 (40 square)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_30_center",
               "content": "qr_rotate_test_30_center",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 30,
               "alignment": "center",
               "verticalAlignment": "middle",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 90 top" },
+            "header": { "content": "rotate: 90 top (40)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_90_top",
               "content": "qr_rotate_test_90_top",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 90,
               "alignment": "left",
               "verticalAlignment": "top",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           },
           {
             "width": "3fr",
-            "header": { "content": "rotate: 90 bottom" },
+            "header": { "content": "rotate: 90 bottom (40)" },
             "cell": {
               "type": "qrCode",
               "name": "rotated_90_bottom",
               "content": "qr_rotate_test_90_bottom",
               "position": { "x": 0, "y": 0 },
-              "width": 30,
+              "width": 40,
               "height": 40,
               "rotate": 90,
               "alignment": "left",
               "verticalAlignment": "bottom",
               "padding": {
-                "top": 8,
-                "right": 8,
-                "bottom": 8,
-                "left": 8
+                "top": 2,
+                "right": 2,
+                "bottom": 2,
+                "left": 2
               }
             }
           }

--- a/templates/qrcode-rotate-test.json
+++ b/templates/qrcode-rotate-test.json
@@ -1,0 +1,142 @@
+{
+  "schemas": [
+    [
+      {
+        "type": "table",
+        "name": "test_table",
+        "position": { "x": 10, "y": 10 },
+        "width": 190,
+        "height": 100,
+        "showHead": true,
+        "headStyles": {
+          "fontSize": 8,
+          "fontName": "NotoSansJP",
+          "alignment": "center",
+          "verticalAlignment": "middle",
+          "lineHeight": 1.0,
+          "fontColor": "#000000",
+          "borderColor": "#000000",
+          "backgroundColor": "#f0f0f0",
+          "borderWidth": {
+            "top": 0.2,
+            "right": 0.2,
+            "bottom": 0.2,
+            "left": 0.2
+          },
+          "padding": {
+            "top": 2,
+            "right": 2,
+            "bottom": 2,
+            "left": 2
+          }
+        },
+        "bodyStyles": {
+          "alignment": "center",
+          "verticalAlignment": "middle",
+          "lineHeight": 1.0,
+          "fontColor": "#000000",
+          "backgroundColor": "#ffffff",
+          "padding": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "lineBreakMode": "char"
+        },
+        "tableStyles": {
+          "borderWidth": 0.2,
+          "borderColor": "#000000"
+        },
+        "columns": [
+          {
+            "width": "3fr",
+            "header": { "content": "no rotate (60)" },
+            "cell": {
+              "type": "qrCode",
+              "name": "no_rotate",
+              "content": "qr_rotate_test_no_rotate",
+              "position": { "x": 0, "y": 0 },
+              "width": 45,
+              "height": 60,
+              "alignment": "center",
+              "verticalAlignment": "middle"
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 30 center" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_30_center",
+              "content": "qr_rotate_test_30_center",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 30,
+              "alignment": "center",
+              "verticalAlignment": "middle",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 90 top" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_90_top",
+              "content": "qr_rotate_test_90_top",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 90,
+              "alignment": "left",
+              "verticalAlignment": "top",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          },
+          {
+            "width": "3fr",
+            "header": { "content": "rotate: 90 bottom" },
+            "cell": {
+              "type": "qrCode",
+              "name": "rotated_90_bottom",
+              "content": "qr_rotate_test_90_bottom",
+              "position": { "x": 0, "y": 0 },
+              "width": 30,
+              "height": 40,
+              "rotate": 90,
+              "alignment": "left",
+              "verticalAlignment": "bottom",
+              "padding": {
+                "top": 8,
+                "right": 8,
+                "bottom": 8,
+                "left": 8
+              }
+            }
+          }
+        ],
+        "fields": [
+          ["", "", "", ""]
+        ]
+      }
+    ]
+  ],
+  "basePdf": {
+    "width": 210,
+    "height": 150,
+    "padding": [10, 10, 10, 10]
+  },
+  "schemaVersion": "1.0.0"
+}

--- a/tests/qr_code_rotation_test.rs
+++ b/tests/qr_code_rotation_test.rs
@@ -1,0 +1,195 @@
+//! Tests for QR Code `rotate` support
+//!
+//! Verifies that `BaseSchema::get_matrix()` retains its original public
+//! signature, that `get_matrix_with_rotation()` accepts an optional
+//! `XObjectRotation`, and that `QrCode::render()` produces a `UseXobject`
+//! transform with the rotation centered on the QR image's intrinsic size.
+
+use pdforge::schemas::base::BaseSchema;
+use pdforge::schemas::qrcode::{JsonQrCodeSchema, QrCode};
+use pdforge::schemas::{Schema, SchemaTrait};
+use pdforge::utils::OpBuffer;
+use printpdf::{Mm, Op, PdfDocument, Px, XObjectRotation, XObjectTransform};
+
+fn qr_dimensions(content: &str) -> (u32, u32) {
+    let code = qrcode::QrCode::new(content).unwrap();
+    let luma = code.render::<image::Luma<u8>>().build();
+    (luma.width(), luma.height())
+}
+
+fn rendered_transform(json: &str) -> XObjectTransform {
+    let json_schema: JsonQrCodeSchema = serde_json::from_str(json).unwrap();
+    let schema: Schema = json_schema.into();
+    let mut doc = PdfDocument::new("rotation_test");
+    let mut buffer = OpBuffer::default();
+    schema
+        .render(Mm(150.0), Mm(210.0), &mut doc, 0, &mut buffer)
+        .unwrap();
+
+    let ops = &buffer.buffer[0];
+    for op in ops {
+        if let Op::UseXobject { transform, .. } = op {
+            return transform.clone();
+        }
+    }
+    panic!("no UseXobject op found in buffer");
+}
+
+#[test]
+fn test_get_matrix_keeps_original_signature_with_no_rotation() {
+    let base = BaseSchema::new("qr".to_string(), Mm(10.0), Mm(20.0), Mm(50.0), Mm(50.0));
+
+    let transform = base.get_matrix(Mm(150.0), Some(Px(256)));
+
+    assert!(transform.rotate.is_none());
+    assert_eq!(transform.translate_x, Some(Mm(10.0).into()));
+}
+
+#[test]
+fn test_get_matrix_without_original_width_uses_identity_scale() {
+    let base = BaseSchema::new("qr".to_string(), Mm(10.0), Mm(20.0), Mm(50.0), Mm(50.0));
+
+    let transform = base.get_matrix(Mm(150.0), None);
+
+    assert_eq!(transform.scale_x, Some(50.0));
+    assert_eq!(transform.scale_y, Some(50.0));
+    assert!(transform.rotate.is_none());
+}
+
+#[test]
+fn test_get_matrix_with_rotation_preserves_rotation() {
+    let base = BaseSchema::new("qr".to_string(), Mm(10.0), Mm(20.0), Mm(50.0), Mm(50.0));
+    let rotation = XObjectRotation {
+        angle_ccw_degrees: 90.0,
+        rotation_center_x: Px(128),
+        rotation_center_y: Px(128),
+    };
+
+    let transform = base.get_matrix_with_rotation(Mm(150.0), Some(Px(256)), Some(rotation.clone()));
+
+    assert_eq!(transform.rotate, Some(rotation));
+}
+
+#[test]
+fn test_get_matrix_with_rotation_none_behaves_like_original() {
+    let base = BaseSchema::new("qr".to_string(), Mm(10.0), Mm(20.0), Mm(50.0), Mm(50.0));
+
+    let transform = base.get_matrix_with_rotation(Mm(150.0), Some(Px(256)), None);
+
+    assert!(transform.rotate.is_none());
+    assert_eq!(transform.scale_x, Some(300.0 / 25.4 / 256.0 * 50.0));
+}
+
+#[test]
+fn test_qrcode_no_rotation_produces_rotate_none() {
+    let json = r#"{
+        "name": "qr",
+        "content": "test_no_rotate",
+        "position": { "x": 10.0, "y": 20.0 },
+        "width": 50.0,
+        "height": 50.0
+    }"#;
+
+    let transform = rendered_transform(json);
+
+    assert!(transform.rotate.is_none());
+}
+
+#[test]
+fn test_qrcode_with_rotation_produces_centered_rotation() {
+    let content = "test_rotate_45";
+    let json = format!(
+        r#"{{
+            "name": "qr",
+            "content": "{}",
+            "position": {{ "x": 10.0, "y": 20.0 }},
+            "width": 50.0,
+            "height": 50.0,
+            "rotate": 45.0
+        }}"#,
+        content
+    );
+
+    let transform = rendered_transform(&json);
+
+    let rotation = transform.rotate.expect("rotation must be set");
+    let (w, h) = qr_dimensions(content);
+    assert_eq!(rotation.angle_ccw_degrees, 45.0);
+    assert_eq!(rotation.rotation_center_x, Px((w / 2) as usize));
+    assert_eq!(rotation.rotation_center_y, Px((h / 2) as usize));
+}
+
+#[test]
+fn test_qrcode_with_rotation_uses_intrinsic_width_for_scale() {
+    let content = "test_scale_90";
+    let json = format!(
+        r#"{{
+            "name": "qr",
+            "content": "{}",
+            "position": {{ "x": 10.0, "y": 20.0 }},
+            "width": 50.0,
+            "height": 50.0,
+            "rotate": 90.0
+        }}"#,
+        content
+    );
+
+    let transform = rendered_transform(&json);
+    let (w, _h) = qr_dimensions(content);
+
+    assert!(transform.rotate.is_some());
+    let expected_scale = 300.0 / 25.4 / (w as f32) * 50.0;
+    assert_eq!(transform.scale_x, Some(expected_scale));
+}
+
+#[test]
+fn test_qrcode_renders_with_rotation_and_alignment_padding() {
+    let json = r#"{
+        "name": "qr",
+        "content": "test_align_pad",
+        "position": { "x": 10.0, "y": 20.0 },
+        "width": 100.0,
+        "height": 100.0,
+        "rotate": 90.0,
+        "alignment": "center",
+        "verticalAlignment": "middle",
+        "padding": { "top": 10.0, "right": 10.0, "bottom": 10.0, "left": 10.0 }
+    }"#;
+
+    let transform = rendered_transform(json);
+
+    // effective box = 100 - (10+10) = 80; center/middle offsets = (80-100)/2 = -10
+    // x = 10 + 10 + (-10) = 10, y = 20 + 10 + (-10) = 20
+    let rotation = transform.rotate.expect("rotation must be set");
+    assert_eq!(rotation.angle_ccw_degrees, 90.0);
+    assert_eq!(transform.translate_x, Some(Mm(10.0).into()));
+    assert_eq!(transform.translate_y, Some(Mm(210.0 - 20.0 - 100.0).into()));
+}
+
+#[test]
+fn test_qrcode_rotate_direction_matches_counter_clockwise_convention() {
+    let mut qr = QrCode::new(
+        "qr".to_string(),
+        Mm(10.0),
+        Mm(20.0),
+        Mm(50.0),
+        Mm(50.0),
+        "test_ccw".to_string(),
+    );
+    qr.set_rotate(90.0);
+
+    let mut doc = PdfDocument::new("rotation_test");
+    let mut buffer = OpBuffer::default();
+    qr.render(Mm(150.0), &mut doc, 0, &mut buffer).unwrap();
+
+    let ops = &buffer.buffer[0];
+    let rotation = ops
+        .iter()
+        .find_map(|op| match op {
+            Op::UseXobject { transform, .. } => transform.rotate.clone(),
+            _ => None,
+        })
+        .expect("rotation must be set");
+
+    assert_eq!(rotation.angle_ccw_degrees, 90.0);
+}

--- a/tests/qr_code_rotation_test.rs
+++ b/tests/qr_code_rotation_test.rs
@@ -9,7 +9,7 @@ use pdforge::schemas::base::BaseSchema;
 use pdforge::schemas::qrcode::{JsonQrCodeSchema, QrCode};
 use pdforge::schemas::{Schema, SchemaTrait};
 use pdforge::utils::OpBuffer;
-use printpdf::{Mm, Op, PdfDocument, Px, XObjectRotation, XObjectTransform};
+use printpdf::{CurTransMat, Mm, Op, PdfDocument, Px, XObjectRotation, XObjectTransform};
 
 fn qr_dimensions(content: &str) -> (u32, u32) {
     let code = qrcode::QrCode::new(content).unwrap();
@@ -33,6 +33,37 @@ fn rendered_transform(json: &str) -> XObjectTransform {
         }
     }
     panic!("no UseXobject op found in buffer");
+}
+
+fn rendered_bounds(transform: &XObjectTransform, width: u32, height: u32) -> [f32; 4] {
+    let matrix = transform
+        .get_ctms(Some((Px(width as usize), Px(height as usize))))
+        .into_iter()
+        .fold(CurTransMat::Identity.as_array(), |combined, next| {
+            CurTransMat::combine_matrix(combined, next.as_array())
+        });
+    let [a, b, c, d, e, f] = matrix;
+    let corners = [
+        (e, f),
+        (a + e, b + f),
+        (c + e, d + f),
+        (a + c + e, b + d + f),
+    ];
+    corners.iter().fold(
+        [
+            f32::INFINITY,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NEG_INFINITY,
+        ],
+        |[min_x, min_y, max_x, max_y], (x, y)| {
+            [min_x.min(*x), min_y.min(*y), max_x.max(*x), max_y.max(*y)]
+        },
+    )
+}
+
+fn assert_approx_eq(left: f32, right: f32) {
+    assert!((left - right).abs() < 0.3, "{left} != {right}");
 }
 
 #[test]
@@ -113,10 +144,10 @@ fn test_qrcode_with_rotation_produces_centered_rotation() {
     let transform = rendered_transform(&json);
 
     let rotation = transform.rotate.expect("rotation must be set");
-    let (w, h) = qr_dimensions(content);
+    let expected_center = Px((50.0_f32 * 300.0 / 25.4 / 2.0).round() as usize);
     assert_eq!(rotation.angle_ccw_degrees, 45.0);
-    assert_eq!(rotation.rotation_center_x, Px((w / 2) as usize));
-    assert_eq!(rotation.rotation_center_y, Px((h / 2) as usize));
+    assert_eq!(rotation.rotation_center_x, expected_center);
+    assert_eq!(rotation.rotation_center_y, expected_center);
 }
 
 #[test]
@@ -158,12 +189,84 @@ fn test_qrcode_renders_with_rotation_and_alignment_padding() {
 
     let transform = rendered_transform(json);
 
-    // effective box = 100 - (10+10) = 80; center/middle offsets = (80-100)/2 = -10
-    // x = 10 + 10 + (-10) = 10, y = 20 + 10 + (-10) = 20
+    // effective box = 100 - (10+10) = 80; QR is square, so side = min(80, 80) = 80
+    // center/middle offsets = (80-80)/2 = 0
+    // x = 10 + 10 + 0 = 20, y = 20 + 10 + 0 = 30
     let rotation = transform.rotate.expect("rotation must be set");
     assert_eq!(rotation.angle_ccw_degrees, 90.0);
-    assert_eq!(transform.translate_x, Some(Mm(10.0).into()));
-    assert_eq!(transform.translate_y, Some(Mm(210.0 - 20.0 - 100.0).into()));
+    assert_eq!(transform.translate_x, Some(Mm(20.0).into()));
+    assert_eq!(transform.translate_y, Some(Mm(210.0 - 30.0 - 80.0).into()));
+    assert_eq!(transform.scale_x, transform.scale_y);
+}
+
+#[test]
+fn test_qrcode_keeps_square_aspect_ratio_in_non_square_box() {
+    let json = r#"{
+        "name": "qr",
+        "content": "test_square",
+        "position": { "x": 10.0, "y": 20.0 },
+        "width": 45.0,
+        "height": 60.0,
+        "rotate": 30.0
+    }"#;
+
+    let transform = rendered_transform(json);
+
+    // QR content must stay 1:1 even when the box is non-square (45x60).
+    // side = min(45, 60) = 45 -> uniform scale, and rotation must not change size.
+    let rotation = transform.rotate.expect("rotation must be set");
+    assert_eq!(rotation.angle_ccw_degrees, 30.0);
+    assert_eq!(
+        transform.scale_x, transform.scale_y,
+        "QR must remain square"
+    );
+
+    let (w, _h) = qr_dimensions("test_square");
+    let expected_scale = 300.0 / 25.4 / (w as f32) * 45.0;
+    assert_eq!(transform.scale_x, Some(expected_scale));
+}
+
+#[test]
+fn test_ninety_degree_rotation_keeps_position_and_size() {
+    let content = "same_content";
+    let unrotated = rendered_transform(
+        r#"{
+            "name": "qr",
+            "content": "same_content",
+            "position": { "x": 65.0, "y": 35.0 },
+            "width": 80.0,
+            "height": 80.0
+        }"#,
+    );
+    let rotated = rendered_transform(
+        r#"{
+            "name": "qr",
+            "content": "same_content",
+            "position": { "x": 65.0, "y": 35.0 },
+            "width": 80.0,
+            "height": 80.0,
+            "rotate": 90.0
+        }"#,
+    );
+
+    assert_eq!(rotated.translate_x, unrotated.translate_x);
+    assert_eq!(rotated.translate_y, unrotated.translate_y);
+    assert_eq!(rotated.scale_x, unrotated.scale_x);
+    assert_eq!(rotated.scale_y, unrotated.scale_y);
+    assert_eq!(
+        rotated
+            .rotate
+            .expect("rotation must be set")
+            .angle_ccw_degrees,
+        90.0
+    );
+
+    let (w, h) = qr_dimensions(content);
+    let unrotated_bounds = rendered_bounds(&unrotated, w, h);
+    let rotated_bounds = rendered_bounds(&rotated, w, h);
+    for (actual, expected) in rotated_bounds.into_iter().zip(unrotated_bounds) {
+        assert_approx_eq(actual, expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds optional QR Code rotation while preserving the QR's rendered position and size. Rotation is counter-clockwise in degrees and uses the center of the final rendered QR square, accounting for printpdf's image/layout transform order.

## Changes

- Keep the existing two-argument `BaseSchema::get_matrix()` API and add `get_matrix_with_rotation()`.
- Render QR codes with a uniform square scale constrained by both the declared size and available box.
- Use the generated image's intrinsic width for scaling instead of the previous hard-coded 256 px value.
- Convert the final rendered QR center to pixels at the transform DPI so rotation does not shift or shrink the QR.
- Add `set_rotate()` for programmatic construction.
- Update the table-based visual example so rotated and unrotated QR codes have the same physical size.
- Add a two-page `qrcode-rotate-same-size` example: both pages use identical content, position, and 80 mm square dimensions; only page 2 rotates 90 degrees.
- Add CTM-bound regression coverage proving the 90-degree result has the same bounds as the unrotated QR.

## Verification

- `cargo fmt --all -- --check`
- `cargo test` — 150 tests passed
- `cargo test --test qr_code_rotation_test` — 11 tests passed
- `cargo run --example qrcode-rotate-test`
- `cargo run --example qrcode-rotate-same-size`
- Rendered PDF inspection: both same-size example pages contain a 296x296 px QR at 94x94 ppi; only orientation differs.
