### PR TITLE
feat: add image and SVG rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ assets/
 .idea/
 .claude/settings.local.json
 .codex/
+.opencode/
 examples/pdf/
 cv_ql800_jpn_raster_101.pdf

--- a/src/schemas/base.rs
+++ b/src/schemas/base.rs
@@ -2,6 +2,26 @@ use printpdf::{Mm, Px, XObjectRotation, XObjectTransform};
 
 pub(crate) const XOBJECT_DPI: f32 = 300.0;
 
+/// Builds a center-pivot rotation after accounting for the XObject's manual scale.
+///
+/// `printpdf` applies image/SVG auto-scaling and `scale_x`/`scale_y` before the
+/// pivot, so an intrinsic `width / 2, height / 2` pivot would shift scaled content.
+pub(crate) fn rotation_for_xobject(
+    angle_ccw_degrees: f32,
+    width: Px,
+    height: Px,
+    transform: &XObjectTransform,
+) -> XObjectRotation {
+    let scale_x = transform.scale_x.unwrap_or(1.0);
+    let scale_y = transform.scale_y.unwrap_or(1.0);
+
+    XObjectRotation {
+        angle_ccw_degrees,
+        rotation_center_x: Px(((width.0 as f32 * scale_x) / 2.0).round().max(0.0) as usize),
+        rotation_center_y: Px(((height.0 as f32 * scale_y) / 2.0).round().max(0.0) as usize),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BaseSchema {
     pub name: String,

--- a/src/schemas/image.rs
+++ b/src/schemas/image.rs
@@ -1,4 +1,7 @@
-use crate::schemas::{base::BaseSchema, Error, HasBaseSchema, JsonPosition, Schema};
+use crate::schemas::{
+    base::{rotation_for_xobject, BaseSchema, XOBJECT_DPI},
+    Error, HasBaseSchema, JsonPosition, Schema,
+};
 use crate::utils::OpBuffer;
 use base64::{engine::general_purpose, Engine as _};
 use image::{DynamicImage, ImageFormat};
@@ -33,6 +36,7 @@ pub struct JsonImageSchema {
     content: String,
     #[serde(default)]
     object_fit: ObjectFit,
+    rotate: Option<f32>,
 }
 
 #[derive(Debug, Clone)]
@@ -40,6 +44,7 @@ pub struct Image {
     base: BaseSchema,
     content: image::DynamicImage,
     object_fit: ObjectFit,
+    rotate: Option<f32>,
 }
 
 impl TryFrom<JsonImageSchema> for Schema {
@@ -58,6 +63,7 @@ impl TryFrom<JsonImageSchema> for Schema {
             base,
             content,
             object_fit: json.object_fit,
+            rotate: json.rotate,
         }))
     }
 }
@@ -90,11 +96,17 @@ impl Image {
             base,
             content,
             object_fit: ObjectFit::default(),
+            rotate: None,
         })
     }
 
     pub fn with_object_fit(mut self, object_fit: ObjectFit) -> Self {
         self.object_fit = object_fit;
+        self
+    }
+
+    pub fn with_rotate(mut self, rotate: f32) -> Self {
+        self.rotate = Some(rotate);
         self
     }
 
@@ -144,9 +156,9 @@ impl Image {
         parent_height: Mm,
         image: &RawImage,
     ) -> XObjectTransform {
-        let dpi: f32 = 300.0;
+        let dpi = XOBJECT_DPI;
 
-        match self.object_fit {
+        let mut transform = match self.object_fit {
             ObjectFit::Fill => {
                 // Use the original scaling logic for Fill mode
                 self.base.get_matrix(parent_height, Some(Px(image.width)))
@@ -270,7 +282,12 @@ impl Image {
                     }
                 }
             }
-        }
+        };
+
+        transform.rotate = self.rotate.map(|angle_deg| {
+            rotation_for_xobject(angle_deg, Px(image.width), Px(image.height), &transform)
+        });
+        transform
     }
 
     pub fn set_x(&mut self, x: Mm) {
@@ -383,6 +400,22 @@ mod tests {
 
         let schema: JsonImageSchema = serde_json::from_str(json).unwrap();
         assert!(matches!(schema.object_fit, ObjectFit::Fill));
+        assert!(schema.rotate.is_none());
+    }
+
+    #[test]
+    fn test_json_image_schema_with_rotation() {
+        let json = r#"{
+            "name": "test-image",
+            "position": {"x": 10.0, "y": 20.0},
+            "width": 100.0,
+            "height": 80.0,
+            "content": "data:image/jpeg;base64,test",
+            "rotate": 90.0
+        }"#;
+
+        let schema: JsonImageSchema = serde_json::from_str(json).unwrap();
+        assert_eq!(schema.rotate, Some(90.0));
     }
 
     #[test]
@@ -498,5 +531,40 @@ mod tests {
         assert!(transform.translate_x.is_some());
         assert!(transform.translate_y.is_some());
         assert_eq!(transform.dpi.unwrap(), 300.0);
+    }
+
+    #[test]
+    fn test_rotation_is_applied_to_every_object_fit_mode() {
+        let mock_raw_image = create_mock_raw_image(200, 100);
+
+        for object_fit in [
+            ObjectFit::Fill,
+            ObjectFit::Contain,
+            ObjectFit::Cover,
+            ObjectFit::None,
+            ObjectFit::ScaleDown,
+        ] {
+            let image = create_test_image()
+                .with_object_fit(object_fit)
+                .with_rotate(90.0);
+            let transform = image.calculate_object_fit_transform(Mm(200.0), &mock_raw_image);
+            let rotation = transform.rotate.expect("rotation must be set");
+
+            assert_eq!(rotation.angle_ccw_degrees, 90.0);
+            assert_eq!(
+                rotation.rotation_center_x,
+                Px(
+                    ((mock_raw_image.width as f32 * transform.scale_x.unwrap()) / 2.0).round()
+                        as usize
+                )
+            );
+            assert_eq!(
+                rotation.rotation_center_y,
+                Px(
+                    ((mock_raw_image.height as f32 * transform.scale_y.unwrap()) / 2.0).round()
+                        as usize
+                )
+            );
+        }
     }
 }

--- a/src/schemas/qrcode.rs
+++ b/src/schemas/qrcode.rs
@@ -1,12 +1,12 @@
 use super::{Alignment, BoundingBox, Frame, VerticalAlignment};
 use crate::schemas::{
-    base::{BaseSchema, XOBJECT_DPI},
+    base::{rotation_for_xobject, BaseSchema},
     Error, HasBaseSchema, JsonPosition, Schema,
 };
 use crate::utils::OpBuffer;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder, Luma};
-use printpdf::{Mm, Op, PdfDocument, Px, RawImage, XObjectRotation};
+use printpdf::{Mm, Op, PdfDocument, Px, RawImage};
 use serde::Deserialize;
 use snafu::ResultExt;
 
@@ -195,18 +195,10 @@ impl QrCode {
         // 新しい基本スキーマを一時的に作成して、正しい位置に変換行列を取得
         let temp_base = BaseSchema::new(self.base.name.clone(), x, y, qr_width, qr_height);
 
-        // printpdf applies the image and layout scales before this pivot. Convert
-        // the center of the final QR square back to pixels at the transform DPI;
-        // using the source image's w/2,h/2 here would move a rotated, scaled QR.
-        let rotation_center = Px((qr_side.0 * XOBJECT_DPI / 25.4 / 2.0).round().max(0.0) as usize);
-        let rotation: Option<XObjectRotation> = self.rotate.map(|angle_deg| XObjectRotation {
-            angle_ccw_degrees: angle_deg,
-            rotation_center_x: rotation_center,
-            rotation_center_y: rotation_center,
+        let mut transform = temp_base.get_matrix(parent_height, Some(qrcode_width));
+        transform.rotate = self.rotate.map(|angle_deg| {
+            rotation_for_xobject(angle_deg, Px(w as usize), Px(h as usize), &transform)
         });
-
-        let transform =
-            temp_base.get_matrix_with_rotation(parent_height, Some(qrcode_width), rotation);
 
         let ops = vec![
             Op::SaveGraphicsState,

--- a/src/schemas/svg.rs
+++ b/src/schemas/svg.rs
@@ -1,8 +1,11 @@
-use crate::schemas::{base::BaseSchema, Error, HasBaseSchema, JsonPosition, Schema};
+use crate::schemas::{
+    base::{rotation_for_xobject, BaseSchema},
+    Error, HasBaseSchema, JsonPosition, Schema,
+};
 use crate::utils::OpBuffer;
 use printpdf::{ExternalXObject, Mm, Op, PdfDocument};
 use serde::Deserialize;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -12,12 +15,14 @@ pub struct JsonSvgSchema {
     width: f32,
     height: f32,
     content: String,
+    rotate: Option<f32>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Svg {
     base: BaseSchema,
     content: ExternalXObject,
+    rotate: Option<f32>,
 }
 
 impl TryFrom<JsonSvgSchema> for Schema {
@@ -32,7 +37,11 @@ impl TryFrom<JsonSvgSchema> for Schema {
             Mm(json.width),
             Mm(json.height),
         );
-        Ok(Schema::Svg(Svg { base, content }))
+        Ok(Schema::Svg(Svg {
+            base,
+            content,
+            rotate: json.rotate,
+        }))
     }
 }
 
@@ -47,7 +56,16 @@ impl Svg {
     ) -> Result<Self, Error> {
         let content = Svg::parse(&content)?;
         let base = BaseSchema::new(name, x, y, width, height);
-        Ok(Self { base, content })
+        Ok(Self {
+            base,
+            content,
+            rotate: None,
+        })
+    }
+
+    pub fn with_rotate(mut self, rotate: f32) -> Self {
+        self.rotate = Some(rotate);
+        self
     }
 
     pub fn get_base(&self) -> BaseSchema {
@@ -69,7 +87,15 @@ impl Svg {
     ) -> Result<(), Error> {
         let svg_x_object_id = doc.add_xobject(&self.content);
 
-        let transform = self.base.get_matrix(parent_height, self.content.width);
+        let mut transform = self.base.get_matrix(parent_height, self.content.width);
+        if let Some(angle_deg) = self.rotate {
+            let (width, height) = self
+                .content
+                .width
+                .zip(self.content.height)
+                .whatever_context("SVG XObject is missing width or height")?;
+            transform.rotate = Some(rotation_for_xobject(angle_deg, width, height, &transform));
+        }
 
         let ops = vec![Op::UseXobject {
             id: svg_x_object_id,
@@ -108,5 +134,72 @@ impl HasBaseSchema for Svg {
     }
     fn base_mut(&mut self) -> &mut BaseSchema {
         &mut self.base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use printpdf::Px;
+
+    const SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+        <rect width="200" height="100" fill="black"/>
+    </svg>"#;
+
+    #[test]
+    fn json_svg_schema_accepts_rotation() {
+        let json = format!(
+            r#"{{
+                "name": "test-svg",
+                "position": {{"x": 10.0, "y": 20.0}},
+                "width": 40.0,
+                "height": 20.0,
+                "content": {},
+                "rotate": 90.0
+            }}"#,
+            serde_json::to_string(SVG).unwrap()
+        );
+
+        let schema: JsonSvgSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(schema.rotate, Some(90.0));
+    }
+
+    #[test]
+    fn render_applies_rotation_around_transformed_svg_center() {
+        let svg = Svg::new(
+            "test-svg".to_string(),
+            Mm(10.0),
+            Mm(20.0),
+            Mm(40.0),
+            Mm(20.0),
+            SVG.to_string(),
+        )
+        .unwrap()
+        .with_rotate(90.0);
+        let mut doc = PdfDocument::new("svg_rotation_test");
+        let mut buffer = OpBuffer::default();
+
+        svg.render(Mm(150.0), &mut doc, 0, &mut buffer).unwrap();
+
+        let transform = buffer.buffer[0]
+            .iter()
+            .find_map(|op| match op {
+                Op::UseXobject { transform, .. } => Some(transform),
+                _ => None,
+            })
+            .expect("UseXobject must be emitted");
+        let rotation = transform.rotate.expect("rotation must be set");
+        let width = svg.content.width.unwrap();
+        let height = svg.content.height.unwrap();
+
+        assert_eq!(rotation.angle_ccw_degrees, 90.0);
+        assert_eq!(
+            rotation.rotation_center_x,
+            Px(((width.0 as f32 * transform.scale_x.unwrap()) / 2.0).round() as usize)
+        );
+        assert_eq!(
+            rotation.rotation_center_y,
+            Px(((height.0 as f32 * transform.scale_y.unwrap()) / 2.0).round() as usize)
+        );
     }
 }

--- a/tests/image_svg_rotation_test.rs
+++ b/tests/image_svg_rotation_test.rs
@@ -1,0 +1,139 @@
+use pdforge::schemas::image::JsonImageSchema;
+use pdforge::schemas::svg::JsonSvgSchema;
+use pdforge::schemas::{Schema, SchemaTrait};
+use pdforge::utils::OpBuffer;
+use printpdf::{CurTransMat, Mm, Op, PdfDocument, Px, XObjectTransform};
+
+const IMAGE_DATA_URL: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+const SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+    <rect width="200" height="100" fill="black"/>
+</svg>"#;
+
+fn render_transform(schema: Schema) -> XObjectTransform {
+    let mut doc = PdfDocument::new("rotation_test");
+    let mut buffer = OpBuffer::default();
+    schema
+        .render(Mm(150.0), Mm(210.0), &mut doc, 0, &mut buffer)
+        .unwrap();
+
+    buffer.buffer[0]
+        .iter()
+        .find_map(|op| match op {
+            Op::UseXobject { transform, .. } => Some(*transform),
+            _ => None,
+        })
+        .expect("UseXobject must be emitted")
+}
+
+fn bounds(transform: &XObjectTransform, width: usize, height: usize) -> [f32; 4] {
+    let matrix = transform
+        .get_ctms(Some((Px(width), Px(height))))
+        .into_iter()
+        .fold(CurTransMat::Identity.as_array(), |combined, next| {
+            CurTransMat::combine_matrix(combined, next.as_array())
+        });
+    let [a, b, c, d, e, f] = matrix;
+    [
+        (e, f),
+        (a + e, b + f),
+        (c + e, d + f),
+        (a + c + e, b + d + f),
+    ]
+    .into_iter()
+    .fold(
+        [
+            f32::INFINITY,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NEG_INFINITY,
+        ],
+        |[min_x, min_y, max_x, max_y], (x, y)| {
+            [min_x.min(x), min_y.min(y), max_x.max(x), max_y.max(y)]
+        },
+    )
+}
+
+fn center(bounds: [f32; 4]) -> (f32, f32) {
+    ((bounds[0] + bounds[2]) / 2.0, (bounds[1] + bounds[3]) / 2.0)
+}
+
+fn assert_same_center(unrotated: [f32; 4], rotated: [f32; 4]) {
+    let (unrotated_x, unrotated_y) = center(unrotated);
+    let (rotated_x, rotated_y) = center(rotated);
+    assert!((unrotated_x - rotated_x).abs() < 0.3);
+    assert!((unrotated_y - rotated_y).abs() < 0.3);
+}
+
+#[test]
+fn image_rotation_keeps_the_transformed_center() {
+    let image_json = |rotate: Option<f32>| {
+        format!(
+            r#"{{
+                "name": "image",
+                "position": {{"x": 30.0, "y": 25.0}},
+                "width": 40.0,
+                "height": 20.0,
+                "content": "{IMAGE_DATA_URL}",
+                "objectFit": "fill"{}
+            }}"#,
+            rotate.map_or(String::new(), |angle| format!(", \"rotate\": {angle}"))
+        )
+    };
+
+    let unrotated: Schema = serde_json::from_str::<JsonImageSchema>(&image_json(None))
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let rotated: Schema = serde_json::from_str::<JsonImageSchema>(&image_json(Some(90.0)))
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let unrotated = render_transform(unrotated);
+    let rotated = render_transform(rotated);
+
+    assert_eq!(
+        rotated
+            .rotate
+            .expect("rotation must be set")
+            .angle_ccw_degrees,
+        90.0
+    );
+    assert_same_center(bounds(&unrotated, 1, 1), bounds(&rotated, 1, 1));
+}
+
+#[test]
+fn svg_rotation_keeps_the_transformed_center() {
+    let svg_json = |rotate: Option<f32>| {
+        format!(
+            r#"{{
+                "name": "svg",
+                "position": {{"x": 30.0, "y": 25.0}},
+                "width": 40.0,
+                "height": 20.0,
+                "content": {}{}
+            }}"#,
+            serde_json::to_string(SVG).unwrap(),
+            rotate.map_or(String::new(), |angle| format!(", \"rotate\": {angle}"))
+        )
+    };
+
+    let unrotated: Schema = serde_json::from_str::<JsonSvgSchema>(&svg_json(None))
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let rotated: Schema = serde_json::from_str::<JsonSvgSchema>(&svg_json(Some(90.0)))
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let unrotated = render_transform(unrotated);
+    let rotated = render_transform(rotated);
+
+    assert_eq!(
+        rotated
+            .rotate
+            .expect("rotation must be set")
+            .angle_ccw_degrees,
+        90.0
+    );
+    assert_same_center(bounds(&unrotated, 200, 100), bounds(&rotated, 200, 100));
+}


### PR DESCRIPTION
## Summary

- Add optional `rotate` support to Image and SVG JSON schemas.
- Rotate around the center of the transformed XObject so scaled content does not shift.
- Support Image rotation across `fill`, `contain`, `cover`, `none`, and `scale-down` object-fit modes.
- Add `with_rotate()` builder methods for programmatic Image and SVG construction.
- Reuse the shared center-pivot calculation for QR codes.
- Ignore the local `.opencode/` directory.

## Verification

- `cargo fmt --all -- --check`
- `cargo test` — 156 tests passed
- Unit coverage for Image JSON decoding, every object-fit mode, and SVG rotation
- Integration coverage verifying Image and SVG retain the same transformed center at 90 degrees
