### PR TITLE
fix: eliminate compilation warnings

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,4 +1,4 @@
-use base64;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let front_base64 = format!(
         "data:image/jpeg;base64,{}",
-        base64::encode(&front_image_data)
+        STANDARD.encode(&front_image_data)
     );
     let back_base64 = format!(
         "data:image/jpeg;base64,{}",
-        base64::encode(&back_image_data)
+        STANDARD.encode(&back_image_data)
     );
 
     let pdforge = pdforge::PDForgeBuilder::new("IMAGE_TEST".to_string())

--- a/src/schemas/mod.rs
+++ b/src/schemas/mod.rs
@@ -459,7 +459,6 @@ impl TryFrom<Vec<f32>> for Frame {
 pub struct Template {
     pub schemas: Vec<serde_json::Value>,
     base_pdf: BasePdf,
-    version: String,
     static_schema_json: Vec<serde_json::Value>,
 }
 
@@ -484,7 +483,6 @@ impl Template {
         let template = Template {
             schemas: json.schemas,
             base_pdf,
-            version: json.version,
             static_schema_json: json.base_pdf.static_schema.clone(),
         };
         Ok(template)
@@ -512,10 +510,9 @@ impl Template {
         // Add date and dateTime using time crate
         let now =
             time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
-        let date_format = time::format_description::parse("[year]-[month]-[day]").unwrap();
+        let date_format = time::macros::format_description!("[year]-[month]-[day]");
         let datetime_format =
-            time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
-                .unwrap();
+            time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
 
         context.insert("date", &now.format(&date_format).unwrap_or_default());
         context.insert(
@@ -844,16 +841,6 @@ impl Template {
         }
 
         self.render_schemas_with_static_inputs(font_map, doc, schemas, static_inputs)
-    }
-
-    // 共通のレンダリング処理
-    fn render_schemas(
-        &self,
-        font_map: &FontMap,
-        doc: &mut PdfDocument,
-        schemas: Vec<Vec<Schema>>,
-    ) -> Result<Vec<u8>, Error> {
-        self.render_schemas_with_static_inputs(font_map, doc, schemas, HashMap::new())
     }
 
     // static inputs対応の共通レンダリング処理

--- a/src/schemas/pdf_utils.rs
+++ b/src/schemas/pdf_utils.rs
@@ -178,12 +178,9 @@ pub fn draw_rectangle(props: DrawRectangle) -> Vec<Op> {
         matrix: CurTransMat::Raw(matrix_values),
     };
 
-    let mode = match props.color {
-        Some(_) => PaintMode::FillStroke,
-        None => PaintMode::Stroke,
-    };
-
-    let mode = if props.color == props.border_color {
+    let mode = if props.color.is_none() {
+        PaintMode::Stroke
+    } else if props.color == props.border_color {
         PaintMode::Fill
     } else {
         PaintMode::FillStroke
@@ -456,6 +453,40 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    fn sample_rectangle(color: Option<Color>, border_color: Option<Color>) -> DrawRectangle {
+        DrawRectangle {
+            x: Mm(10.0),
+            y: Mm(10.0),
+            width: Mm(20.0),
+            height: Mm(20.0),
+            rotate: None,
+            page_height: Mm(100.0),
+            color,
+            border_width: Some(Mm(0.1)),
+            border_color,
+        }
+    }
+
+    #[test]
+    fn rectangle_without_fill_uses_stroke_mode() {
+        let ops = draw_rectangle(sample_rectangle(None, None));
+
+        assert_eq!(polygon_modes(&ops), vec![PaintMode::Stroke]);
+    }
+
+    #[test]
+    fn rectangle_with_matching_fill_and_border_uses_fill_mode() {
+        let color = Color::Rgb(Rgb {
+            r: 0.5,
+            g: 0.5,
+            b: 0.5,
+            icc_profile: None,
+        });
+        let ops = draw_rectangle(sample_rectangle(Some(color.clone()), Some(color)));
+
+        assert_eq!(polygon_modes(&ops), vec![PaintMode::Fill]);
     }
 
     #[test]

--- a/src/schemas/text.rs
+++ b/src/schemas/text.rs
@@ -637,7 +637,7 @@ impl HasBaseSchema for Text {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use printpdf::{FontId, Mm, ParsedFont, PdfDocument, Pt};
+    use printpdf::{Mm, ParsedFont, PdfDocument, Pt};
     use serde_json::json;
     use std::path::PathBuf;
     use std::sync::{Arc, OnceLock};
@@ -688,19 +688,6 @@ mod tests {
         ) -> Result<Pt, crate::font::Error> {
             Ok(self.height)
         }
-    }
-
-    // Note: These tests are simplified to avoid complex font construction
-    // Integration tests should be used for full font functionality testing
-    #[cfg(test)]
-    fn create_test_text_without_font() -> (BaseSchema, FontId, Arc<MockFontSpec>) {
-        let base = BaseSchema::new("test".to_string(), Mm(10.0), Mm(10.0), Mm(100.0), Mm(50.0));
-        let font_id = FontId::new();
-        let font_spec = Arc::new(MockFontSpec {
-            width_result: Pt(20.0),
-            height: Pt(12.0),
-        });
-        (base, font_id, font_spec)
     }
 
     fn test_font() -> Arc<ParsedFont> {

--- a/tests/schema_traits_tests.rs
+++ b/tests/schema_traits_tests.rs
@@ -7,7 +7,6 @@
 
 use pdforge::schemas::base::BaseSchema;
 use pdforge::schemas::qrcode::QrCode;
-use pdforge::schemas::rect::Rect;
 use pdforge::schemas::{BoundingBox, HasBaseSchema, Schema, SchemaTrait};
 use pdforge::utils::OpBuffer;
 use printpdf::{Mm, PdfDocument};
@@ -16,7 +15,6 @@ use printpdf::{Mm, PdfDocument};
 #[derive(Debug, Clone)]
 struct MockSchema {
     base: BaseSchema,
-    custom_value: i32,
 }
 
 impl MockSchema {
@@ -29,7 +27,6 @@ impl MockSchema {
                 Mm(width),
                 Mm(height),
             ),
-            custom_value: 42,
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace deprecated time format parsing and Base64 encoding APIs
- remove unused production and test code
- fix the shadowed rectangle paint mode calculation
- add regression tests for stroke-only and matching fill/border rectangle modes

## Verification

- cargo fmt --check
- cargo test --all-targets
- cargo build
- git diff --check